### PR TITLE
Fix returns

### DIFF
--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -6,7 +6,7 @@ DIRECTORY_PATH=$1
 
 if [ -z "$1" ]; then
 	echo "You must pass a directory name to hash"
-	return 1
+	exit 1
 fi
 
 # - Find all files in the given directory

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -4,7 +4,7 @@ set -e
 
 if [ -z "$1" ]; then
 	echo "You must pass a filename to hash"
-	return 1
+	exit 1
 fi
 
 shasum -a 256 "$1" | cut -f1 -d " "

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -7,7 +7,7 @@ CACHE_KEY=$2
 
 if [ -z "$CACHE_FILE" ]; then
 	echo "You must pass the file or directory you want to be cached"
-	return 1
+	exit 1
 fi
 
 # We can automatically derive a cache key if one isn't provided
@@ -33,7 +33,7 @@ if [ -z "$CACHE_BUCKET_NAME" ]; then
 		CACHE_BUCKET_NAME="$BUILDKITE_PLUGIN_BASH_CACHE_BUCKET"
 	else
 		echo "⛔Unable to save file to cache – no \$CACHE_BUCKET_NAME is set"
-		return 1
+		exit 1
 	fi
 fi
 


### PR DESCRIPTION
You can't use `return` in a shell script – we should use `exit` instead.