### PR TITLE
Remove hardcoded bucket names

### DIFF
--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -11,7 +11,7 @@ if aws s3api head-object --bucket "$CACHE_BUCKET_NAME" --key "$CACHE_KEY" > /dev
 	echo "Restoring cache entry $CACHE_KEY"
 
 	echo "	Downloading"
-	aws s3 cp "s3://a8c-ci-cache/$CACHE_KEY" "$CACHE_KEY" --quiet
+	aws s3 cp "s3://$CACHE_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 
 	echo "	Decompressing"
 	tar -xf "$CACHE_KEY"

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -42,7 +42,7 @@ echo "Using $CACHE_BUCKET_NAME as cache bucket"
 SHOULD_FORCE=${3-false}
 if [[ "$SHOULD_FORCE" == '--force' ]]; then
 	echo "Deleting the existing cache key"
-	aws s3 rm "s3://a8c-ci-cache/$CACHE_KEY"
+	aws s3 rm "s3://$CACHE_BUCKET_NAME/$CACHE_KEY"
 fi
 
 if ! aws s3api head-object --bucket "$CACHE_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1; then


### PR DESCRIPTION
Hi! :wave:

I noticed a couple of hardcoded bucket names in the `restore_cache` and `save_cache` scripts and thought I'd remove them