### PR TITLE
Add a new `add_host_to_ssh_known_hosts` command

### DIFF
--- a/bin/add_host_to_ssh_known_hosts
+++ b/bin/add_host_to_ssh_known_hosts
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+# Parameter can be just a host name, or a full http, https or git URL. Defaults to `github.com`.
+URL=${1:-github.com}
+
+# Use a RegEx to extract the $HOST. Match the optional `http://`, `https://` or `git@` at the start, then capture everything after that up to the next `/` or `:`.
+[[ $URL =~ ^(https?://|git@)?([^/:]+) ]] && HOST=${BASH_REMATCH[2]}
+
+echo "Adding ${HOST} to '~/.ssh/known_hosts'..."
+for ip in $(dig @8.8.8.8 ${HOST} +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true

--- a/bin/add_host_to_ssh_known_hosts
+++ b/bin/add_host_to_ssh_known_hosts
@@ -7,4 +7,4 @@ URL=${1:-github.com}
 [[ $URL =~ ^(https?://|git@)?([^/:]+) ]] && HOST=${BASH_REMATCH[2]}
 
 echo "Adding ${HOST} to '~/.ssh/known_hosts'..."
-for ip in $(dig @8.8.8.8 ${HOST} +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
+for ip in $(dig @8.8.8.8 "${HOST}" +short); do ssh-keyscan "${HOST}",$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true

--- a/bin/add_host_to_ssh_known_hosts
+++ b/bin/add_host_to_ssh_known_hosts
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
-# Parameter can be just a host name, or a full http, https or git URL. Defaults to `github.com`.
-URL=${1:-github.com}
+# Parameter can be just a host name, or a full http, https or git URL.
+URL="${1:?You need to provide an URL as first parameter}"
 
 # Use a RegEx to extract the $HOST. Match the optional `http://`, `https://` or `git@` at the start, then capture everything after that up to the next `/` or `:`.
 [[ $URL =~ ^(https?://|git@)?([^/:]+) ]] && HOST=${BASH_REMATCH[2]}

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -3,10 +3,7 @@
 sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
 
 # Trust all GitHub.com and BitBucket.org keys – this allows checking out dependencies via SSH
-for ip in $(dig @8.8.8.8 bitbucket.org +short); do ssh-keyscan bitbucket.org,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
-echo ":bitbucket: Added BitBucket IP Addresses to known_hosts"
-
-for ip in $(dig @8.8.8.8 github.com +short); do ssh-keyscan github.com,$ip; ssh-keyscan $ip; done 2>/dev/null >> ~/.ssh/known_hosts || true
-echo ":github: Added GitHub IP Addresses to known_hosts"
+add_host_to_ssh_known_hosts bitbucket.org
+add_host_to_ssh_known_hosts github.com
 
 xcodebuild -resolvePackageDependencies

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -12,8 +12,11 @@ ssh-add -D
 ssh-add ~/.ssh/pod_repo_push_deploy_key
 ssh-add -l
 
+# Add the host of the spec repo (typically github.com) to the known_hosts to be sure we can clone it via ssh
+add_host_to_ssh_known_hosts "$PRIVATE_SPECS_REPO"
+
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod repo push $PRIVATE_SPECS_REPO $PODSPEC_PATH
+bundle exec pod repo push "$PRIVATE_SPECS_REPO" "$PODSPEC_PATH"


### PR DESCRIPTION
### Why

So that we can easily add any URL or host to the `~/.ssh/known_hosts` and ensure connecting to it (especially `git clone`) won't leave the CI hanging on an interactive prompt asking if we trust the host.

### How

**Usage**: `add_host_to_ssh_known_hosts <HOST_OR_FULL_URL>`. Defaults to `github.com` as the host to add if no parameter provided.

Also updated the `publish_private_pod` command to call this new one before calling `pod repo push` to ensure that cloning our spec repo won't get stuck in that interactive prompt.

### To test

1. I pointed https://github.com/Automattic/MobilePay-Apple/pull/19 to this branch of the plugin and am testing this from here.
2. If you want to test the `add_host_to_ssh_known_hosts` properly for all scenarios, you could:
   - Clone this branch
   - Optionally edit the file to remove the `>> ~/.ssh/known_hosts || true` at the end of last line, to avoid polluting your local `known_hosts` file
   - Run `bin/add_host_to_ssh_known_hosts` and check that it ~runs the command for `github.com`~ displays an error telling you you need to provide an URL as parameter
   - Run `bin/add_host_to_ssh_known_hosts foo.bar` and check that it extracted the host as`foo.bar` (it won't find any entry in the DNS for it so won't print any `ssh-keyscan` results, it being an non-existing host)
   - Run `bin/add_host_to_ssh_known_hosts git@foo.bar` and check it runs the command for `foo.bar`
   - Run `bin/add_host_to_ssh_known_hosts git@foo.bar:path/to/dir` and check it runs the command for `foo.bar`
   - Run `bin/add_host_to_ssh_known_hosts http://foo.bar/path/to/dir` and check it runs the command for `foo.bar`
   - Run `bin/add_host_to_ssh_known_hosts https://foo.bar/path/to/dir` and check it runs the command for `foo.bar`
   - Run `bin/add_host_to_ssh_known_hosts https://foo.bar/path/to/dir?q=12#x` and check it runs the command for `foo.bar`

Once this is validated, we probably want to publish a new version of the plugin