### PR TITLE
Add SSH Key to Agent Function

### DIFF
--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+NEW_SSH_KEY=$1
+NEW_SSH_KEY_NAME=$2
+
+# Create key in ~/.ssh dir
+echo "$NEW_SSH_KEY" > ~/.ssh/"$NEW_SSH_KEY_NAME"
+chmod 0600 ~/.ssh/"$NEW_SSH_KEY_NAME"
+
+# Add new key to Agent
+ssh-add ~/.ssh/"$NEW_SSH_KEY_NAME"
+ssh-add -l

--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -8,5 +8,7 @@ echo "$NEW_SSH_KEY" > ~/.ssh/"$NEW_SSH_KEY_NAME"
 chmod 0600 ~/.ssh/"$NEW_SSH_KEY_NAME"
 
 # Add new key to Agent
+echo "Deleting keys and adding new key"
+ssh-add -D
 ssh-add ~/.ssh/"$NEW_SSH_KEY_NAME"
 ssh-add -l

--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -8,7 +8,5 @@ echo "$NEW_SSH_KEY" > ~/.ssh/"$NEW_SSH_KEY_NAME"
 chmod 0600 ~/.ssh/"$NEW_SSH_KEY_NAME"
 
 # Add new key to Agent
-echo "Deleting keys and adding new key"
-ssh-add -D
 ssh-add ~/.ssh/"$NEW_SSH_KEY_NAME"
 ssh-add -l


### PR DESCRIPTION
Creates a small function to add a ssh key from an environment variable to the running ssh-agent. 

- This also creates a key file, this can be avoided if desired with something like `echo $NEW_SSH_KEY | ssh-add -`
- It does not clear existing keys
- [The reason it was created did not work due to an issue with how git clone works with authentication and deploy keys.](https://www.webfactory.de/blog/using-multiple-ssh-deploy-keys-with-github)

## Usage: 
`add_ssh_key_to_agent "${exported_SSH_KEY}" name-of-exported-ssh-key-file`