### PR TITLE
Fix quotation in build_and_test_pod [breaking change]

### DIFF
--- a/bin/build_and_test_pod
+++ b/bin/build_and_test_pod
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
-
-# Allow the fastlane lane name to be passed as the first argument, but default to `test`
-LANE_NAME="${1:-test}"
+#
+# Any arguments passed to this script will be passed through to `fastlane`.
+# If no argument is passed, the `test` lane will be called by default.
 
 echo "--- :rubygems: Setting up Gems"
 install_gems
@@ -24,14 +24,4 @@ echo "--- :test_tube: Building and Running Tests"
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-# FIXME: Missing quotation of $LANE_NAME
-#
-# The fact that $LANE_NAME is not quoted here means that if we pass something
-# like a quoted 'foo bar' as the sole parameter of this script, this will in
-# fact end up calling 'fastlane foo bar' (with 2 parameters to fastlane)
-#
-# We should instead use something like "$@" – which expands to each paramater passed
-# to the script, automatically individually quoted. This would be a breaking change
-# though, so should only be done when we're ready to do a major version bump and
-# update all call sites relying on this.
-bundle exec fastlane $LANE_NAME
+bundle exec fastlane "${@:-test}"


### PR DESCRIPTION
This fixes the [SC2046 violation](https://www.shellcheck.net/wiki/SC2046) which made the `build_and_test_pod` command not consume its arguments correctly, breaking if any arguments passed contained spaces.

ℹ️  Note that this PR is built on top of #12 (and targeting the `shellcheck` branch)

## ⚠️  Breaking Change

Note that this is a breaking change which will require us to do a major version bump once we land and ship this.

We will then need to check if any of our `pipeline.yml` calling this `build_and_test_pod` relied on this bug and passed a parameters with spaces in them, to instead call them as individual parameters as usually intended.

### Example of such repo requiring fixing

One of such [known instances](https://github.com/Automattic/bash-cache-buildkite-plugin/pull/12#discussion_r757896302) where this bug was exploited was in the `MobilePay-Apple` repo [here](https://github.com/Automattic/MobilePay-Apple/blob/develop/.buildkite/pipeline.yml#L15).

That particular call in this repo's pipeline will have to be changed to this instead (to remove the quotes that made these 2 arguments be seen as one before):

```diff
-    command: "build_and_test_pod 'ios test'"
+    command: "build_and_test_pod ios test"
```

and similar change in the (currently commented out) line 22 of that same file:
```diff
-  #   command: "build_and_test_pod 'mac test'"
+  #   command: "build_and_test_pod mac test"
```

Of course we shall not forget to also bump the plugin reference in the `pipeline.yml` to point it to its new major version `automattic/bash-cache#2.0.0: ~` at the same time we apply those changes in those repos.