### PR TITLE
Enable shellcheck on files in bin/* too

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ":shell: Lint (Shellcheck)"
     plugins:
       shellcheck#v1.1.2:
-        files: hooks/**
+        files: ["hooks/**", "bin/**"]
 
   - label: ":sparkles: Lint (Buildkite Plugin Linter)"
     plugins:

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -15,7 +15,7 @@ restore_cache "$LOCAL_CACHE_KEY"
 # If the `pod check` plugin is installed, use it to determine whether or not to install Pods at all
 # If it's not installed (or if it fails), we'll try to install Pods. 
 # If that fails, it may be due to an out-of-date repo. We can use `--repo-update` to try to resolve this automatically.
-if [ $(bundle exec pod plugins installed | grep check) ]; then
+if bundle exec pod plugins installed | grep -q check; then
 	bundle exec pod check || bundle exec pod install || bundle exec pod install --repo-update --verbose
 else
 	bundle exec pod install || bundle exec pod install --repo-update --verbose

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -2,7 +2,7 @@
 
 PODSPEC_PATH=$1
 
-POD_NAME=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.name')
+# POD_NAME=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.name')
 POD_VERSION=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.version')
 
 if [ ! -z "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -5,7 +5,7 @@ PODSPEC_PATH=$1
 # POD_NAME=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.name')
 POD_VERSION=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.version')
 
-if [ ! -z "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then
+if [ -n "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then
 	echo "Tag $BUILDKITE_TAG does not match version $POD_VERSION from $PODSPEC_PATH."
 	exit 1
 fi

--- a/bin/validate_gemfile_lock
+++ b/bin/validate_gemfile_lock
@@ -3,9 +3,9 @@
 # We always need to run `bundle install` first, otherwise we can't compare
 bundle install
 
-if [ -n "$(git status | grep modified | grep Gemfile.lock)" ]; then 
+if git status | grep modified | grep -q Gemfile.lock; then 
 	echo "Error: Gemfile.lock is not in sync – please run \`bundle install\` and commit your changes"
 	exit 1
-fi 
+fi
 
 echo "Gemfile.lock is in sync"


### PR DESCRIPTION
Implements the Platform Request pdnsEh-4c-p2 to lint all our shell scripts in `bin/`.

This PR is cut from the `shellcheck` branch to build on top of the violations I already fixed in #12.

### Fixing Current Violations

It is ready for review, even though the CI to currently red. This is because we _do_ have some violations in our current shell scripts that we'll need to fix first

Having the CI be currently red is a good way to show that when we have shellcheck violations they are properly reported.

But now that we got that [initial `shellcheck` report on CI](https://buildkite.com/wordpress-mobile/bash-cache-buildkite-plugin/builds/136#9167f396-760c-4440-833a-5553fb5e1096), we should fix the existing violations first via the other PRs before rebasing this PR on top of the fixes and merging it to `trunk`. See the [comment below](https://github.com/Automattic/bash-cache-buildkite-plugin/pull/15#issuecomment-988058530) for a suggestion on the plan around the order in which we should merge the various currently-open PRs, to make everything work nicely and be fixed in the right order.