### PR TITLE
Use platform-agnostic hashing functions

### DIFF
--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -11,4 +11,4 @@ fi
 # - Run `sha256sum` on each file found – the `+` flag does it in parallel for a huge speed boost.
 # - Sort the files by filename for deterministic hashing
 # - Take the hash of all of the output hashes (and file paths)
-find "$DIRECTORY_PATH" -type f -exec shasum -a 256 "{}" \+ | sort -k 2 | shasum -a 256 | cut -f1 -d " "
+find "$DIRECTORY_PATH" -type f -exec sha256sum "{}" \+ | sort -k 2 | shasum -a 256 | cut -f1 -d " "

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -5,4 +5,4 @@ if [ -z "$1" ]; then
 	exit 1
 fi
 
-shasum -a 256 "$1" | cut -f1 -d " "
+sha256sum "$1" | cut -f1 -d " "


### PR DESCRIPTION
Make hashing work on linux by using `sha256sum` in place of `shasum -a 256` (which was only Mac-compatible).

This shouldn't be a breaking change, but the worst-case scenario is that some caches would need to be regenerated, which would happen automatically (though it would slow down the first run of each build until the caches were restored).

**To Test:**
Note that https://github.com/woocommerce/woocommerce-android/pull/5862 passes (specifically, the Installable Build task) – it uses this branch when installing Ruby dependencies.