### PR TITLE
Add check to ensure `pod install` doesn't change `Podfile.lock`

### DIFF
--- a/bin/hash_file
+++ b/bin/hash_file
@@ -9,4 +9,13 @@ fi
 # printing the error message if `$1` was unbound.
 set -u
 
-sha256sum "$1" | cut -f1 -d " "
+# `shasum` is available on only macOS
+if command -v shasum &> /dev/null; then
+  sha_command='shasum -a 256'
+else
+  sha_command='sha256sum'
+fi
+
+# Both `shasum` and `sha256sum` will print the hash and the file name (`$1`).
+# We only care about the hash, so we use `cut` to extract it.
+$sha_command $1 | cut -f1 -d " "

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -5,8 +5,8 @@ if [ -z "$1" ]; then
 	exit 1
 fi
 
-# Calling this here otherwise the `-z "$1"` above would have failed without
-# printing the error message if `$1` was unbound.
+# Calling `set -u` here instead of the shebang otherwise the `-z "$1"` above
+# would fail without printing the error message if `$1` was unbound.
 set -u
 
 # `shasum` is available on only macOS

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -18,4 +18,4 @@ fi
 
 # Both `shasum` and `sha256sum` will print the hash and the file name (`$1`).
 # We only care about the hash, so we use `cut` to extract it.
-$sha_command $1 | cut -f1 -d " "
+$sha_command "$1" | cut -f1 -d " "

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -1,8 +1,12 @@
-#!/bin/bash -eu
+#!/bin/bash -e
 
 if [ -z "$1" ]; then
 	echo "You must pass a filename to hash"
 	exit 1
 fi
+
+# Calling this here otherwise the `-z "$1"` above would have failed without
+# printing the error message if `$1` was unbound.
+set -u
 
 sha256sum "$1" | cut -f1 -d " "

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -13,7 +13,7 @@ LOCAL_CACHE_KEY="$BUILDKITE_PIPELINE_SLUG-local-pod-cache-$PODFILE_HASH"
 restore_cache "$LOCAL_CACHE_KEY"
 
 # If the `pod check` plugin is installed, use it to determine whether or not to install Pods at all
-# If it's not installed (or if it fails), we'll try to install Pods. 
+# If it's not installed (or if it fails), we'll try to install Pods.
 # If that fails, it may be due to an out-of-date repo. We can use `--repo-update` to try to resolve this automatically.
 if bundle exec pod plugins installed | grep -q check; then
 	bundle exec pod check || bundle exec pod install || bundle exec pod install --repo-update --verbose

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -32,7 +32,9 @@ else
 fi
 
 function lockfile_error () {
-  echo "Podfile.lock was changed by 'pod install'. Please run 'pod install' and try again."
+  message='`Podfile.lock` was changed by `bundle exec pod install`. Please run `bundle exec pod install` locally with a clean cache and commit the result.'
+  echo $message
+  buildkite-agent annotate "$message" --style 'error' --context 'ctx-error'
 }
 trap lockfile_error ERR
 

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -37,7 +37,8 @@ function lockfile_error () {
 trap lockfile_error ERR
 
 echo "Checking that Podfile.lock was not modified by 'pod install'"
-echo "${PODFILE_HASH} Podfile.lock" | $sha_command --check --status
+# Notice the two spaces as per shasum/sha256sum output
+echo "${PODFILE_HASH}  Podfile.lock" | $sha_command --check --status
 
 # Remove trap for the lockfile error now that we've done the check.
 trap - ERR

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -23,13 +23,21 @@ fi
 
 # Check that `Podfile.lock` was unchanged by `pod install`. If it was, it means
 # the lockfile might have been inadvertently changed.
+
+# `shasum` is available only on macOS
+if command -v shasum &> /dev/null; then
+  sha_command='shasum -a 256'
+else
+  sha_command='sha256sum'
+fi
+
 function lockfile_error () {
   echo "Podfile.lock was changed by 'pod install'. Please run 'pod install' and try again."
 }
 trap lockfile_error ERR
 
 echo "Checking that Podfile.lock was not modified by 'pod install'"
-echo "${PODFILE_HASH} Podfile.lock" | sha256sum --check --status
+echo "${PODFILE_HASH} Podfile.lock" | $sha_command --check --status
 
 # Remove trap for the lockfile error now that we've done the check.
 trap - ERR

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -32,8 +32,8 @@ else
 fi
 
 function lockfile_error () {
-  message='`Podfile.lock` was changed by `bundle exec pod install`. Please run `bundle exec pod install` locally with a clean cache and commit the result.'
-  echo $message
+  message="\`Podfile.lock\` was changed by \`bundle exec pod install\`. Please run \`bundle exec pod install\` locally with a clean cache and commit the result."
+  echo "$message"
   buildkite-agent annotate "$message" --style 'error' --context 'ctx-error'
 }
 trap lockfile_error ERR

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -21,5 +21,18 @@ else
 	bundle exec pod install || bundle exec pod install --repo-update --verbose
 fi
 
+# Check that `Podfile.lock` was unchanged by `pod install`. If it was, it means
+# the lockfile might have been inadvertently changed.
+function lockfile_error () {
+  echo "Podfile.lock was changed by 'pod install'. Please run 'pod install' and try again."
+}
+trap lockfile_error ERR
+
+echo "Checking that Podfile.lock was not modified by 'pod install'"
+echo "${PODFILE_HASH} Podfile.lock" | sha256sum --check --status
+
+# Remove trap for the lockfile error now that we've done the check.
+trap - ERR
+
 # If this is the first time we've seen this particular hash of `Podfile.lock`, create a cache entry for future use
 save_cache Pods "$LOCAL_CACHE_KEY"


### PR DESCRIPTION
This PR:

- Adds a check to ensure that the tracked `Podfile.lock` matches what the `Podfile` would generate on a clean install. This should prevent issues such as https://github.com/wordpress-mobile/WordPress-iOS/pull/18145 and https://github.com/wordpress-mobile/WordPress-iOS/pull/18211
- Updates the hashing logic to work on both macOS and Linux after a recent change

~I created https://github.com/wordpress-mobile/WordPress-iOS/pull/18212 to test this change, but I noticed [something quite odd](https://buildkite.com/automattic/wordpress-ios/builds/6247#d5d69166-6260-4fd3-8a01-0dec82e3d316):~

~`/usr/local/var/buildkite-agent/plugins/github-com-automattic-bash-cache-buildkite-plugin-5015983/bin/hash_file:
line 8: sha256sum: command not found`~

~~For reference, the `sha256sum` was introduced in https://github.com/Automattic/bash-cache-buildkite-plugin/pull/18.~~

See [this build](https://buildkite.com/automattic/wordpress-ios/builds/6347) for an example of how the logic catches issues and [this other build](https://buildkite.com/automattic/wordpress-ios/builds/6346#2918d078-cbd3-4dd9-9bc9-dbd9060784c7) to verify that, [once the issue is addressed](https://github.com/wordpress-mobile/WordPress-iOS/commit/323b7818e07162f02430214195a7a2a657a0edd4), everything is green.

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1218433/160736091-2604f951-6cd4-4948-9c48-456731cd8ec8.png">