### PR TITLE
Simplify `hash_file` by defaulting `$1` to empty string in `if` check

### DIFF
--- a/bin/hash_file
+++ b/bin/hash_file
@@ -1,13 +1,9 @@
-#!/bin/bash -e
+#!/bin/bash -eu
 
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
 	echo "You must pass a filename to hash"
 	exit 1
 fi
-
-# Calling `set -u` here instead of the shebang otherwise the `-z "$1"` above
-# would fail without printing the error message if `$1` was unbound.
-set -u
 
 # `shasum` is available on only macOS
 if command -v shasum &> /dev/null; then


### PR DESCRIPTION
Hat tip @AliSoftware. See https://github.com/Automattic/bash-cache-buildkite-plugin/pull/19#discussion_r839393747

To test, run `bin/hash_file` with and without a file as argument.

![image](https://user-images.githubusercontent.com/1218433/161895589-0245ac63-12d2-414a-a2b5-34e09ce87921.png)
