### PR TITLE
Correctly parse SSH key from single-line env var in `add_ssh_key_to_agent`

### DIFF
--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -4,9 +4,10 @@ NEW_SSH_KEY=$1
 NEW_SSH_KEY_NAME=$2
 
 # Create key in ~/.ssh dir
-echo "$NEW_SSH_KEY" > ~/.ssh/"$NEW_SSH_KEY_NAME"
-chmod 0600 ~/.ssh/"$NEW_SSH_KEY_NAME"
+NEW_SSH_KEY_PATH="$HOME"/.ssh/"$NEW_SSH_KEY_NAME"
+echo "$NEW_SSH_KEY" > "$NEW_SSH_KEY_PATH"
+chmod 0600 "$NEW_SSH_KEY_PATH"
 
 # Add new key to Agent
-ssh-add ~/.ssh/"$NEW_SSH_KEY_NAME"
+ssh-add "$NEW_SSH_KEY_PATH"
 ssh-add -l

--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -5,7 +5,7 @@ NEW_SSH_KEY_NAME=$2
 
 # Create key in ~/.ssh dir
 NEW_SSH_KEY_PATH="$HOME"/.ssh/"$NEW_SSH_KEY_NAME"
-echo "$NEW_SSH_KEY" > "$NEW_SSH_KEY_PATH"
+echo -e "$NEW_SSH_KEY" > "$NEW_SSH_KEY_PATH"
 chmod 0600 "$NEW_SSH_KEY_PATH"
 
 # Add new key to Agent


### PR DESCRIPTION
Fixes #20. The trick was to call `echo -e` instead of `echo`.

Without the `-e` flag, the `\n` in the single-line string where the SSH key stored were printed literally in the SSH key file, making it an invalid key.

You can see this in action in 3927-gh-shiftyjelly/pocketcasts-ios.