### PR TITLE
Adds save & restore gradle dependency cache scripts

### DIFF
--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# The key is shared with bin/restore_gradle_dependency_cache
+# The key is shared with `bin/save_gradle_dependency_cache`
 GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+
+# The key is shared with bin/restore_gradle_dependency_cache
+GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+
+echo "Restoring Gradle dependency cache..."
+
+# `save_cache` & `restore_cache` scripts only work if they are called from the same directory
+pushd "$GRADLE_RO_DEP_CACHE_BASE_FOLDER"
+restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY"
+popd
+
+echo "---"

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+# The key is shared with bin/restore_gradle_dependency_cache
+GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+
+echo "Saving Gradle dependency cache..."
+
+mkdir -p "$GRADLE_RO_DEP_CACHE"
+
+# https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:cache_copy
+# Gradle suggests removing the "*.lock" files and the `gc.properties` file before saving cache
+cp -r ~/.gradle/caches/modules-2 "$GRADLE_RO_DEP_CACHE" \
+    && find "$GRADLE_RO_DEP_CACHE" -name "*.lock" -type f -delete \
+    && find "$GRADLE_RO_DEP_CACHE" -name "gc.properties" -type f -delete
+
+# `save_cache` & `restore_cache` scripts only work if they are called from the same directory
+pushd "$GRADLE_RO_DEP_CACHE_BASE_FOLDER"
+# For now we are using a single key - we might expand on this later by using dependency catalog version
+save_cache "$GRADLE_RO_DEP_CACHE_FOLDER_NAME" "$GRADLE_DEPENDENCY_CACHE_KEY" --force
+popd
+
+echo "---"

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# The key is shared with bin/restore_gradle_dependency_cache
+# The key is shared with `bin/restore_gradle_dependency_cache`
 GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
 
 echo "Saving Gradle dependency cache..."
@@ -8,7 +8,7 @@ echo "Saving Gradle dependency cache..."
 mkdir -p "$GRADLE_RO_DEP_CACHE"
 
 # https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:cache_copy
-# Gradle suggests removing the "*.lock" files and the `gc.properties` file before saving cache
+# Gradle suggests removing the `*.lock` files and the `gc.properties` file before saving cache
 cp -r ~/.gradle/caches/modules-2 "$GRADLE_RO_DEP_CACHE" \
     && find "$GRADLE_RO_DEP_CACHE" -name "*.lock" -type f -delete \
     && find "$GRADLE_RO_DEP_CACHE" -name "gc.properties" -type f -delete


### PR DESCRIPTION
This PR adds save & restore gradle dependency cache scripts. We'll be saving our dependency cache from the https://github.com/Automattic/android-dependency-catalog/ project and restoring it to all our Android project. (in time)

It uses Gradle's read only cache feature and follows the [steps from official documentation](https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:shared-readonly-cache). By using the read only dependency cache feature and not the `$GRADLE_HOME/caches` folder, we are making it safer to use this cache as it won't interfere with regular Gradle execution. It should also be faster since it doesn't deal with locks and it's easier to disable per project as we can simply remove the `GRADLE_RO_DEP_CACHE` environment variable.

The script uses the `GRADLE_RO_DEP_CACHE_BASE_FOLDER` & `GRADLE_RO_DEP_CACHE_FOLDER_NAME` environment variables, added to our CI `env` files in `.mobile-secrets`. I'd have liked to not use these keys and instead just rely on `GRADLE_RO_DEP_CACHE` which is what Gradle needs. However, our `save_cache` & `restore_cache` scripts depend on the working directory and I had many issues trying to get it work for this setup. Specifically `tar` removing the leading `/` (for security) made things complicated. I could have written a couple commands to separate the `GRADLE_RO_DEP_CACHE`, but I thought these extra keys made things easier to understand especially with the comments added in the `env` file in `.mobile-secrets`. Happy to improve the scripts if anyone has any other suggestions!

**To test**

* `save_gradle_dependency_cache` script is utilized by `android-dependency-catalog` project [here](https://github.com/Automattic/android-dependency-catalog/blob/trunk/.buildkite/cache.sh#L10). Here is [a sample build log](https://buildkite.com/automattic/android-dependency-catalog/builds/65#530b7a28-5910-4bd7-8998-2265db987a44) showing that cache was successfully saved.
* `restore_gradle_dependency_cache` is utilized in https://github.com/woocommerce/woocommerce-android/pull/6527 which has testing instructions showcasing that the cache was successfully restored.