### PR TITLE
Use dirname & basename for Gradle dependency cache logic

### DIFF
--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -5,8 +5,10 @@ GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."
 
+DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_RO_DEP_CACHE")
+
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
-pushd "$GRADLE_RO_DEP_CACHE_BASE_FOLDER"
+pushd "$DEP_CACHE_BASE_FOLDER"
 restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY"
 popd
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -13,10 +13,13 @@ cp -r ~/.gradle/caches/modules-2 "$GRADLE_RO_DEP_CACHE" \
     && find "$GRADLE_RO_DEP_CACHE" -name "*.lock" -type f -delete \
     && find "$GRADLE_RO_DEP_CACHE" -name "gc.properties" -type f -delete
 
+DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_RO_DEP_CACHE")
+DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_RO_DEP_CACHE")
+
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
-pushd "$GRADLE_RO_DEP_CACHE_BASE_FOLDER"
+pushd "$DEP_CACHE_BASE_FOLDER"
 # For now we are using a single key - we might expand on this later by using dependency catalog version
-save_cache "$GRADLE_RO_DEP_CACHE_FOLDER_NAME" "$GRADLE_DEPENDENCY_CACHE_KEY" --force
+save_cache "$DEP_CACHE_FOLDER_NAME" "$GRADLE_DEPENDENCY_CACHE_KEY" --force
 popd
 
 echo "---"


### PR DESCRIPTION
This PR uses `dirname` & `basename` for figuring out where the Gradle dependency cache should be saved/restored from instead of using `GRADLE_RO_DEP_CACHE_BASE_FOLDER` & `GRADLE_RO_DEP_CACHE_FOLDER_NAME` `env` vars.

We could do this without depending on `dirname` & `basename`, but this is clearer than pure Bash solution, so I think the  tradeoff is worth it.