### PR TITLE
Add command to annotate Unit/UI Test failures on the Buildkite page

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     plugins:
       shellcheck#v1.2.0:
         files: ["hooks/**", "bin/**"]
-        options: ["-e", SC1071"] # Ignore scripts that are not written in bash (especially ruby scripts)
+        options: ["--exclude=SC1071"] # Ignore scripts that are not written in bash (especially ruby scripts)
 
   - label: ":sparkles: Lint (Buildkite Plugin Linter)"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     plugins:
       shellcheck#v1.2.0:
         files: ["hooks/**", "bin/**"]
-        options: "-e SC1071" # Ignore scripts that are not written in bash (especially ruby scripts)
+        options: ["-e", SC1071"] # Ignore scripts that are not written in bash (especially ruby scripts)
 
   - label: ":sparkles: Lint (Buildkite Plugin Linter)"
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: ":shell: Lint (Shellcheck)"
     plugins:
-      shellcheck#v1.1.2:
+      shellcheck#v1.2.0:
         files: ["hooks/**", "bin/**"]
         options: "-e SC1071" # Ignore scripts that are not written in bash (especially ruby scripts)
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,7 @@ steps:
     plugins:
       shellcheck#v1.1.2:
         files: ["hooks/**", "bin/**"]
+        options: "-e SC1071" # Ignore scripts that are not written in bash (especially ruby scripts)
 
   - label: ":sparkles: Lint (Buildkite Plugin Linter)"
     plugins:

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -5,7 +5,7 @@
 #
 require 'rexml/document'
 
-junit_path = ARGV.first || File.join('build/results/report.junit')
+junit_path = ARGV.first || File.join('build', 'results', 'report.junit')
 title = ENV.fetch('BUILDKITE_LABEL', 'Tests')
 
 file = File.open(junit_path)
@@ -13,17 +13,17 @@ xmldoc = REXML::Document.new(file)
 
 failures = []
 REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
-    failure = testcase.elements['failure']
-    failures.append <<~ENTRY
-    <details><summary><tt>#{testcase['name']}</tt> in <tt>#{testcase['classname']}</tt></summary>
-    
-    #{failure['message']}
+  failure = testcase.elements['failure']
+  failures.append <<~ENTRY
+  <details><summary><tt>#{testcase['name']}</tt> in <tt>#{testcase['classname']}</tt></summary>
+  
+  #{failure['message']}
 
-    ```
-    #{failure.text}
-    ```
-    </details>
-    ENTRY
+  ```
+  #{failure.text}
+  ```
+  </details>
+  ENTRY
 end
 
 markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -8,6 +8,11 @@ require 'rexml/document'
 junit_path = ARGV.first || File.join('build', 'results', 'report.junit')
 title = ENV.fetch('BUILDKITE_LABEL', 'Tests')
 
+unless File.exist?(junit_path)
+  puts "JUnit file not found: #{junit_path}."
+  exit 0
+end
+
 file = File.open(junit_path)
 xmldoc = REXML::Document.new(file)
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+#
+# Usage:
+#   annotate-test-failures [junit-file-path]
+#
+require 'rexml/document'
+
+junit_path = ARGV.first || File.join('build/results/report.junit')
+title = ENV.fetch('BUILDKITE_LABEL', 'Tests')
+
+file = File.open(junit_path)
+xmldoc = REXML::Document.new(file)
+
+failures = []
+REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
+    failure = testcase.elements['failure']
+    failures.append <<~ENTRY
+    <details><summary><tt>#{testcase['name']}</tt> in <tt>#{testcase['classname']}</tt></summary>
+    
+    #{failure['message']}
+
+    ```
+    #{failure.text}
+    ```
+    </details>
+    ENTRY
+end
+
+markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
+system('buildkite-agent', 'annotate', '--style', 'error', '--context', title)

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -32,12 +32,12 @@ REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
 end
 
 if failures.empty?
-  puts "No test failure found. Removing any previous `#{title}` Buildkite annotation."
+  puts "No test failure found. Removing any previous `#{title}` Buildkite annotation if any."
   system('buildkite-agent', 'annotation', 'remove', '--context', title)
+  exit 0 # We don't want to fail if the `annotation remove` command failed because there was no previous annotation
 else
   puts "Found #{failures.count} test failure(s). Reporting them as a `#{title}` Buildkite annotation."
   markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
   system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
+  exit $?.exitstatus
 end
-
-exit $?.exitstatus

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -27,4 +27,4 @@ REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
 end
 
 markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
-system('buildkite-agent', 'annotate', '--style', 'error', '--context', title)
+system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
 # Usage:
-#   annotate-test-failures [junit-file-path]
+#   annotate_test_failures [junit-file-path]
 #
 require 'rexml/document'
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# shellcheck disable=all
+
 #
 # Usage:
 #   annotate-test-failures [junit-file-path]

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -1,6 +1,4 @@
 #!/usr/bin/env ruby
-# shellcheck disable=all
-
 #
 # Usage:
 #   annotate-test-failures [junit-file-path]

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -31,8 +31,13 @@ REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
   ENTRY
 end
 
-puts "Reporting #{failures.count} failure(s) using `buildkite-agent annotate`"
-markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
-system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
+if failures.empty?
+  puts "No test failure found. Removing any previous `#{title}` Buildkite annotation."
+  system('buildkite-agent', 'annotation', 'remove', '--context', title)
+else
+  puts "Found #{failures.count} test failure(s). Reporting them as a `#{title}` Buildkite annotation."
+  markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
+  system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
+end
 
 exit $?.exitstatus

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -10,6 +10,7 @@ title = ENV.fetch('BUILDKITE_LABEL', 'Tests')
 
 unless File.exist?(junit_path)
   puts "JUnit file not found: #{junit_path}."
+  # Don't fail if `.junit` file not found to avoid "hiding" the failure in the build that resulted in the that file not being created
   exit 0
 end
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -26,5 +26,8 @@ REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
   ENTRY
 end
 
+puts "Reporting #{failures.count} failure(s) using `buildkite-agent annotate`"
 markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
 system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
+
+exit $?.exitstatus


### PR DESCRIPTION
The PR provides a command to annotate Buildkite builds with annotations showing test failures at the top of the Buildkite job page.

## Context

This work is a follow-up of what I've been playing with in https://github.com/wordpress-mobile/WordPress-iOS/pull/18952 — this mainly moves the feature from the client repo into this plugin so that more projects can benefit from this.

> **Note** I've reimplemented the logic from using an XSLT (what I used in the WPiOS PR originally) to using a ruby script, because while XSLTs are nice and powerful, and `xsltproc` is installed by default on every macOS standard installation and thus each `mac` agent and VM we use in Buildkite, this might not be available in other client repos using other agents like `android`. While having ruby available in the build agents is more common (e.g. both iOS and Android clients use `fastlane` and thus have `ruby` installed in some capacity)

## To Test

This new command is used in https://github.com/wordpress-mobile/WordPress-iOS/pull/18961, so if that WPiOS PR properly reports test failures as Buildkite annotations, we can consider this working.