### PR TITLE
Ensure we're using the latest version of `bundler` before running `bundle install`

### DIFF
--- a/bin/install_gems
+++ b/bin/install_gems
@@ -7,7 +7,9 @@ CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH
 
 restore_cache "$CACHEKEY"
 
-# Ensure we're using the latest version of Bundler before running bundle install
+# Ensure we're using the latest version of Bundler before running bundle install.
+#
+# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16  for more details on why this is recommended.
 gem install bundler
 bundle install
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -6,6 +6,9 @@ GEMFILE_HASH=$(hash_file Gemfile.lock)
 CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH"
 
 restore_cache "$CACHEKEY"
+
+# Ensure we're using the latest version of Bundler before running bundle install
+gem install bundler
 bundle install
 
 # If this is the first time we've seen this particular cache key, save it for the future


### PR DESCRIPTION
Fixes https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16

Installs the latest version of `bundler` to avoid `Gem::LoadError` crashes when using mismatching versions.

