### PR TITLE
Add Test Analytics Upload Action

### DIFF
--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -1,21 +1,21 @@
 #!/bin/bash -eu
 
 if [ -z "${1: }" ]; then
-	echo "You must pass a path to the file you want to upload to Test Analytics"
-	exit 1
+  echo "You must pass a path to the file you want to upload to Test Analytics"
+  exit 1
 fi
 
 if [ -z "${2: }" ]; then
-	echo "You must pass a Buildkite Analytics Token"
-	exit 1
+  echo "You must pass a Buildkite Analytics Token"
+  exit 1
 fi
 
 FILE_PATH=$1
 ANALYTICS_TOKEN=$2
 
 if [ ! -f "$FILE_PATH" ]; then
-	echo "No file exists at $FILE_PATH. Cancelling Upload"
-	exit 0
+  echo "No file exists at $FILE_PATH. Cancelling Upload"
+  exit 0
 fi
 
 echo "Uploading ${FILE_PATH} to Test Analytics"

--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -15,6 +15,8 @@ ANALYTICS_TOKEN=$2
 
 if [ ! -f "$FILE_PATH" ]; then
   echo "No file exists at $FILE_PATH. Cancelling Upload"
+
+  # Clean exit, to avoid invalidating an entire run because of a missing artifact
   exit 0
 fi
 

--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+
+FILE_PATH=$1
+ANALYTICS_TOKEN=$2
+
+if [ -z "$FILE_PATH" ]; then
+	echo "You must pass a path to the file you want to upload to Test Analytics"
+	exit 1
+fi
+
+if [ -z "$ANALYTICS_TOKEN" ]; then
+	echo "You must pass a Buildkite Analytics Token"
+	exit 1
+fi
+
+if [ ! -f "$FILE_PATH" ]; then
+	echo "No file exists at $FILE_PATH. Cancelling Upload"
+	exit 0
+fi
+
+echo "Uploading ${FILE_PATH} to Test Analytics"
+
+curl -X POST \
+  -H "Authorization: Token token=$ANALYTICS_TOKEN" \
+  -F "format=junit" \
+  -F "data=@$FILE_PATH" \
+  -F "run_env[CI]=buildkite" \
+  -F "run_env[key]=$BUILDKITE_BUILD_ID" \
+  -F "run_env[number]=$BUILDKITE_BUILD_NUMBER" \
+  -F "run_env[job_id]=$BUILDKITE_JOB_ID" \
+  -F "run_env[branch]=$BUILDKITE_BRANCH" \
+  -F "run_env[commit_sha]=$BUILDKITE_COMMIT" \
+  -F "run_env[message]=$BUILDKITE_MESSAGE" \
+  -F "run_env[url]=$BUILDKITE_BUILD_URL" \
+  https://analytics-api.buildkite.com/v1/uploads

--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -1,17 +1,17 @@
 #!/bin/bash -eu
 
-FILE_PATH=$1
-ANALYTICS_TOKEN=$2
-
-if [ -z "$FILE_PATH" ]; then
+if [ -z "${1: }" ]; then
 	echo "You must pass a path to the file you want to upload to Test Analytics"
 	exit 1
 fi
 
-if [ -z "$ANALYTICS_TOKEN" ]; then
+if [ -z "${2: }" ]; then
 	echo "You must pass a Buildkite Analytics Token"
 	exit 1
 fi
+
+FILE_PATH=$1
+ANALYTICS_TOKEN=$2
 
 if [ ! -f "$FILE_PATH" ]; then
 	echo "No file exists at $FILE_PATH. Cancelling Upload"


### PR DESCRIPTION
Adds a Test Analytics Action (used by https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2472) that makes uploading JUnit XML files a one-liner ([without any bash-pipe-curl stuff](https://github.com/buildkite/test-collector-junit)).