### PR TITLE
Install Bundler version from `Gemfile.lock` + `add_ruby_env_info`

### DIFF
--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+echo "--- :ruby: Ruby environment info dump"
+set -x
+which ruby
+ruby --version
+
+which gem
+gem --version
+
+which bundle
+gem list bundler
+bundle version
+set -x

--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-echo "--- :ruby: Ruby environment info dump"
+echo "--- :ruby: Ruby environment info dump ${1:-}"
 set -x
 which ruby
 ruby --version

--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,6 +1,13 @@
 #!/bin/bash -eu
 
 echo "--- :ruby: Ruby environment info dump ${1:-}"
+
+if [[ -f .ruby-version ]]; then
+  cat .ruby-version
+else
+  echo 'Could not find .ruby-version in current folder'
+fi
+
 set -x # debug mode: print the commands we call
 
 which ruby

--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,7 +1,8 @@
 #!/bin/bash -eu
 
 echo "--- :ruby: Ruby environment info dump ${1:-}"
-set -x
+set -x # debug mode: print the commands we call
+
 which ruby
 ruby --version
 
@@ -11,4 +12,5 @@ gem --version
 which bundle
 gem list bundler
 bundle version
-set -x
+
+set +x # exit debug mode

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -9,8 +9,6 @@ CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH
 
 restore_cache "$CACHEKEY"
 
-dump_ruby_env_info 'after running restore_cache'
-
 # Install the same Bundler version as the one in the Gemfile.lock.
 # This should prevent runtime issues where Ruby "gets confused" on which Bundler version to use.
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details.

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -14,9 +14,8 @@ dump_ruby_env_info 'after running restore_cache'
 # Ensure we're using the latest version of Bundler before running bundle install.
 #
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details on why this is recommended.
-gem uninstall bundler
-gem install bundler
-dump_ruby_env_info 'after running gem install bundler'
+gem install bundler:"$( (tail -1 | sed 's/ *//g') < Gemfile.lock)"
+dump_ruby_env_info 'after running gem install bundler with constrained version'
 
 bundle install
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -14,6 +14,7 @@ dump_ruby_env_info 'after running restore_cache'
 # Ensure we're using the latest version of Bundler before running bundle install.
 #
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details on why this is recommended.
+gem uninstall bundler
 gem install bundler
 dump_ruby_env_info 'after running gem install bundler'
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -9,21 +9,13 @@ CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH
 
 restore_cache "$CACHEKEY"
 
+dump_ruby_env_info 'after running restore_cache'
+
 # Ensure we're using the latest version of Bundler before running bundle install.
 #
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details on why this is recommended.
 gem install bundler
-# Even after adding the call above, we get occasional failure due to Bundler version issues.
-#
-# To learn more about the issue:
-#
-# 1. Dump information
-# 2. Run `rbenv rehash`, which is recommended after install executables
-dump_ruby_env_info 'before rbenv rehash'
-rbenv rehash
-
-# Dump info again to see if anything changed after rehashing
-dump_ruby_env_info 'after rbenv rehash'
+dump_ruby_env_info 'after running gem install bundler'
 
 bundle install
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -1,14 +1,13 @@
 #!/bin/bash -eu
 
+dump_ruby_env_info "before running $(basename "$0")"
+
 ARCHITECTURE=$(uname -m)
 RUBY_VERSION=$(cat .ruby-version)
 GEMFILE_HASH=$(hash_file Gemfile.lock)
 CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH"
 
 restore_cache "$CACHEKEY"
-
-# Dump some info about the Ruby environment, more details about why we do this below.
-dump_ruby_env_info
 
 # Ensure we're using the latest version of Bundler before running bundle install.
 #

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -11,11 +11,13 @@ restore_cache "$CACHEKEY"
 
 dump_ruby_env_info 'after running restore_cache'
 
-# Ensure we're using the latest version of Bundler before running bundle install.
-#
-# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details on why this is recommended.
-gem install bundler:"$( (tail -1 | sed 's/ *//g') < Gemfile.lock)"
-dump_ruby_env_info 'after running gem install bundler with constrained version'
+# Install the same Bundler version as the one in the Gemfile.lock.
+# This should prevent runtime issues where Ruby "gets confused" on which Bundler version to use.
+# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details.
+GEMFILE_LOCK_BUNDLER_VERSION=$(sed -n -e '/BUNDLED WITH/{n;s/ *//p;}' Gemfile.lock)
+gem install bundler --version "$GEMFILE_LOCK_BUNDLER_VERSION"
+
+dump_ruby_env_info "after running gem install bundler version $GEMFILE_LOCK_BUNDLER_VERSION"
 
 bundle install
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -13,6 +13,7 @@ restore_cache "$CACHEKEY"
 # This should prevent runtime issues where Ruby "gets confused" on which Bundler version to use.
 # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details.
 GEMFILE_LOCK_BUNDLER_VERSION=$(sed -n -e '/BUNDLED WITH/{n;s/ *//p;}' Gemfile.lock)
+# The command will fail if the `--version` parameter is empty; we can omit checking for that ourselves.
 gem install bundler --version "$GEMFILE_LOCK_BUNDLER_VERSION"
 
 dump_ruby_env_info "after running gem install bundler version $GEMFILE_LOCK_BUNDLER_VERSION"

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -19,11 +19,11 @@ gem install bundler
 #
 # 1. Dump information
 # 2. Run `rbenv rehash`, which is recommended after install executables
-dump_ruby_env_info
+dump_ruby_env_info 'before rbenv rehash'
 rbenv rehash
 
 # Dump info again to see if anything changed after rehashing
-dump_ruby_env_info
+dump_ruby_env_info 'after rbenv rehash'
 
 bundle install
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -7,10 +7,25 @@ CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH
 
 restore_cache "$CACHEKEY"
 
+# Dump some info about the Ruby environment, more details about why we do this below.
+dump_ruby_env_info
+
 # Ensure we're using the latest version of Bundler before running bundle install.
 #
-# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16  for more details on why this is recommended.
+# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 for more details on why this is recommended.
 gem install bundler
+# Even after adding the call above, we get occasional failure due to Bundler version issues.
+#
+# To learn more about the issue:
+#
+# 1. Dump information
+# 2. Run `rbenv rehash`, which is recommended after install executables
+dump_ruby_env_info
+rbenv rehash
+
+# Dump info again to see if anything changed after rehashing
+dump_ruby_env_info
+
 bundle install
 
 # If this is the first time we've seen this particular cache key, save it for the future

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -1,7 +1,5 @@
 #!/bin/bash -eu
 
-dump_ruby_env_info "before running $(basename "$0")"
-
 ARCHITECTURE=$(uname -m)
 RUBY_VERSION=$(cat .ruby-version)
 GEMFILE_HASH=$(hash_file Gemfile.lock)
@@ -15,8 +13,6 @@ restore_cache "$CACHEKEY"
 GEMFILE_LOCK_BUNDLER_VERSION=$(sed -n -e '/BUNDLED WITH/{n;s/ *//p;}' Gemfile.lock)
 # The command will fail if the `--version` parameter is empty; we can omit checking for that ourselves.
 gem install bundler --version "$GEMFILE_LOCK_BUNDLER_VERSION"
-
-dump_ruby_env_info "after running gem install bundler version $GEMFILE_LOCK_BUNDLER_VERSION"
 
 bundle install
 


### PR DESCRIPTION
Despite the `gem install bundler` call in `install_gems` we recently see a come back of the `Gem::LoadError: You have already activated bundler...` error from https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16 .

~~I don't know how to fix the issue, but this PR adds info dumps that will hopefully help understand more about its cause.~~

Update: The current best solution is to install the same bundler version as the one tracked in `Gemfile.lock` (original suggestion from #16). The approach has been implemented here and verified [in this Woo demo PR](https://github.com/woocommerce/woocommerce-ios/pull/7820) were the installing the Bundler version from `Gemfile.lock` didn't result in the `Gem::LoadError...` error. See build [here](https://buildkite.com/automattic/woocommerce-ios/builds/8248#0183aeb7-19b5-4ab7-a5be-ec909228ed4c).

<img width="692" alt="image" src="https://user-images.githubusercontent.com/1218433/194400366-9220b2cd-31e4-4e82-9cdd-ff5c3dff634b.png">

These debug calls already revealed something interesting: CI has _two_ `default` Bundler versions, which seems like a probable cause for the "you have already activated..." version issue.

I couldn't find an explanation for that `default` in the `gem list --help`, so I [posted a StackOverflow question](https://stackoverflow.com/questions/73967910/how-can-gem-list-show-multiple-default-versions-for-a-gem) about it.