### PR TITLE
Add a script to validate Swift package

### DIFF
--- a/bin/validate_swift_package
+++ b/bin/validate_swift_package
@@ -12,5 +12,4 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- :test_tube: Building and testing the Swift Package"
-
 bundle exec fastlane "${@:-test}"

--- a/bin/validate_swift_package
+++ b/bin/validate_swift_package
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+#
+# Any arguments passed to this script will be passed through to `fastlane`.
+# If no argument is passed, the `test` lane will be called by default.
+
+if [[ ! -f Package.swift ]]; then
+    echo "This repo is not a Swift package."
+    exit
+fi
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :test_tube: Building and testing the Swift Package"
+
+bundle exec fastlane "${@:-test}"


### PR DESCRIPTION
This script is based on [`build_and_test_pod`](https://github.com/Automattic/bash-cache-buildkite-plugin/blob/688461e48115844a2e71099b69d4b4e7d7bb6f3e/bin/build_and_test_pod).

See https://github.com/Automattic/Gridicons-iOS/pull/71 for how this script is going to be used.