### PR TITLE
Adds Gradle Wrapper Validation script

### DIFF
--- a/bin/validate_gradle_wrapper
+++ b/bin/validate_gradle_wrapper
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+
+CHECKSUM_URLS=$(curl -s https://services.gradle.org/versions/all | jq -r ".[].wrapperChecksumUrl? | select(.)")
+
+function validate_checksum() {
+    wrapper_file="$1"
+    validated_with_checksum_from_url=""
+
+    wrapper_checksum=$(sha256sum "$wrapper_file")
+    # Remove the file location from the "wrapper_checksum" result
+    sha256_checksum_to_be_validated="${wrapper_checksum%% *}"
+
+    while IFS= read -r checksum_url; do
+        downloaded_checksum=$(curl -s --location "$checksum_url")
+        if [[ "$sha256_checksum_to_be_validated" == "$downloaded_checksum" ]]; then
+            validated_with_checksum_from_url="$checksum_url"
+            break;
+        fi
+    done <<< "$CHECKSUM_URLS"
+
+    if [[ -z "$validated_with_checksum_from_url" ]]; then
+        echo "Failed to validate '$wrapper_file'"
+        exit 1
+    else
+        echo "'$wrapper_file' is validated with sha256 checksum from '$validated_with_checksum_from_url'"
+    fi
+}
+
+WRAPPER_JARS=$(find . -type f -name "gradle-wrapper.jar")
+if [ -z "${WRAPPER_JARS}" ]; then
+    echo "No gradle-wrapper.jar files found."
+    exit 1
+else
+    while IFS= read -r wrapper_file; do
+        validate_checksum "$wrapper_file"
+    done <<< "$WRAPPER_JARS"
+fi

--- a/bin/validate_gradle_wrapper
+++ b/bin/validate_gradle_wrapper
@@ -6,9 +6,7 @@ function validate_checksum() {
     wrapper_file="$1"
     validated_with_checksum_from_url=""
 
-    wrapper_checksum=$(sha256sum "$wrapper_file")
-    # Remove the file location from the "wrapper_checksum" result
-    sha256_checksum_to_be_validated="${wrapper_checksum%% *}"
+    sha256_checksum_to_be_validated=$(hash_file "$wrapper_file")
 
     while IFS= read -r checksum_url; do
         downloaded_checksum=$(curl -s --location "$checksum_url")


### PR DESCRIPTION
This PR adds `bin/validate_gradle_wrapper` helper script which we can use to validate the Gradle Wrapper in our projects using Buildkite.

During the implementation of this script, I've consulted with the [official Gradle Wrapper Documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html#manually_verifying_the_gradle_wrapper_jar) as well as the [official Gradle Wrapper Validation Github Action](https://github.com/gradle/wrapper-validation-action). Here is a summary of what the script does:

* Finds all files with the name `gradle-wrapper.jar`. If no such file is found, it'll fail with the following error: `No gradle-wrapper.jar files found.` This is because if we don't have any Gradle Wrapper files in the project, we shouldn't be calling this script. If we do and it still fails, it's possibly due to Homoglyph attack. (more on that below)
* If there is at least one `gradle-wrapper.jar` file, the script will download the json from `https://services.gradle.org/versions/all` and make a list of urls of all the known `sha256` hashes using the `wrapperChecksumUrl` property.
* Since the `sha256` values are not directly listed in the `json` file, but instead have to be downloaded from a url, we have to check each url until we find a match. We can possibly avoid this by using the Gradle wrapper version information, but that adds extra complexity and it's more error prone, so in my opinion, checking each known value is better. The good news is, since we use relatively latest Gradle versions in each project, we only end up checking a few versions.
* If we find a match for the `gradle-wrapper.jar` file, we'll log that information as such: `'./gradle/wrapper/gradle-wrapper.jar' is validated with sha256 checksum from 'https://services.gradle.org/distributions/gradle-7.4.2-wrapper.jar.sha256'`. This information allows us to always come back to a build and check how it was validated.
* We'll validate each `gradle-wrapper.jar` file, which in most cases will only be one, and if each of them is validated, the script will return success return code. If any of the files fail to validate, it'll exit with an error as such: `Failed to validate './gradle/wrapper/gradle-wrapper.jar'`.

---

**Combining with Official Github Action**

We initially wanted to use the Official Github Action, but it becomes a bit messy to use that as a prerequisite for our Buildkite actions. So, @jkmassel and I had a discussion about using our own script as a prerequisite, but also adding the Github Action as an extra piece of security. That means, if there is a validation error that our script misses, we'll at least know about it and address the issue in our script. This makes our script more future-proof and gives extra coverage for Homoglyph attacks.

---

**Homoglyph Attacks**

The main difference with this script and the official Github Action is that, this script doesn't cover all cases of Homoglyph attacks. The official Github Action will [unhomoglyph](https://github.com/nodeca/unhomoglyph) each file and then if a file's name corresponds to `gradle-wrapper.jar`, it'll validate it.

On the contrary, since this script only looks for `gradle-wrapper.jar` file, if the file is a homoglyphed version, it'll not find it. That means - in most cases, it'll exit with a failure because it didn't find any `gradle-wrapper.jar` files. However, there is still a case this script doesn't cover and that is, **if the project contains both a valid `gradle-wrapper.jar` file as well as a homoglyphed one, it'll return a false positive validation.**

I looked into adding the same Homoglyph file name validation to the bash script, but I think it's a bit tricky and messy to do it in bash. I also thought that `gradle-wrapper.jar` file is probably not the only file that can be used to attack. So, in my opinion, if this is something we are worried about, we should add a more generic check to our repositories where we block any Homoglyphed file names using a list of names we keep in a central location. If we go down that route, we can use the [unhomoglyph](https://github.com/nodeca/unhomoglyph) library to avoid another re-write of something that already exists.

Specifically for Gradle Wrapper validation; since we are also adding the Github Action, I don't think we should worry about it. We are already handling the Gradle upgrades ourselves. Once we start using this script as well as the Github Action, I think we will have more than enough coverage.

---

**To Test**

* You can see this script in action in https://github.com/wordpress-mobile/WordPress-Android/pull/17480.
* If you want to test the script locally, you can call it directly from any directory and it'll validate every `gradle-wrapper.jar` file within it.
* If you want to simulate a homoglyph attack coverage, you can download the `gradle-wrapper.jar` file from [this PR](https://github.com/JLLeitschuh/playframework/pull/1/files), put it in a temporary directory and run this script which should fail with `No gradle-wrapper.jar files found.`.