### PR TITLE
validate_swift_package fails if it's not running in a Swift pacakge

### DIFF
--- a/bin/validate_swift_package
+++ b/bin/validate_swift_package
@@ -5,7 +5,7 @@
 
 if [[ ! -f Package.swift ]]; then
     echo "This repo is not a Swift package."
-    exit
+    exit 1
 fi
 
 echo "--- :rubygems: Setting up Gems"


### PR DESCRIPTION
Follow up PR of https://github.com/Automattic/bash-cache-buildkite-plugin/pull/33#discussion_r1017830554.