### PR TITLE
Add command to run `.strings` file generation

### DIFF
--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -22,10 +22,10 @@ LOGS=logs.txt
 set +e
 set -o pipefail
 if [[ $# -eq 0 ]]; then
-  bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
-else
-  bundle exec fastlane "$@" | tee $LOGS
+  # If no argument provided, update $@ with default values
+  set -- generate_strings_file_for_glotpress skip_commit:true
 fi
+bundle exec fastlane "$@" | tee $LOGS
 EXIT_CODE=$?
 set -e
 

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+
+# Attempts to generate the frozen `.strings` file to gets sent to GlotPress
+# after a new release code freeze.
+#
+# If the process fails, annotates the build with the errors.
+
+# The strings generation happens via Fastlane, so we need to install the
+# Ruby gems.
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+# The strings generation also picks up files from our first party libraries,
+# some of which are installed via CocoaPods
+echo "--- :cocoapods: Setting up Pods"
+install_cocoapods
+
+echo "--- :sleuth_or_spy: Lint Apple Localized Strings Format"
+# A next step improvement is to move the logs management within the release
+# toolkit
+LOGS=logs.txt
+set +e
+set -o pipefail
+bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
+EXIT_CODE=$?
+set -e
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  # Strings generation finished with errors, extract the errors in an easy-to-find section
+  echo "+++ :x: Strings Generation Failed"
+  ERRORS=errors.txt
+  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`*LocalizedStrings\` calls:" | tee $ERRORS
+  echo '' >> $ERRORS
+  # Print the errors inline.
+  #
+  # Notice the second `sed` call that removes the ANSI escape sequences that
+  # Fastlane uses to color the output.
+  grep -e "\[.*\].*genstrings:" $LOGS \
+    | sed -e 's/\[.*\].*genstrings: error: /- /' \
+    | sed -e $'s/\x1b\[[0-9;]*m//g' \
+    | sort \
+    | uniq \
+    | tee -a $ERRORS
+  # Annotate the build with the errors
+  cat $ERRORS | buildkite-agent annotate --style error --context genstrings
+fi
+
+exit $EXIT_CODE

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -29,14 +29,19 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   # Strings generation finished with errors, extract the errors in an easy-to-find section
   echo "+++ :x: Strings Generation Failed"
   ERRORS=errors.txt
-  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`{NS,App}LocalizedStrings\` calls:" | tee $ERRORS
-  echo '' >> $ERRORS
+  printf "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`{NS,App}LocalizedStrings\` calls:\n\n" | tee $ERRORS
   # Print the errors inline.
   #
   # Notice the second `sed` call that removes the ANSI escape sequences that
-  # Fastlane uses to color the output.
-  grep -e "\[.*\].*genstrings:" $LOGS \
-    | sed -e 's/\[.*\].*genstrings: error: /- /' \
+  # Fastlane uses to color the output. We need to do this at this point to
+  # account for Fastlane printing the errors multiple times (inline and in the
+  # end of the lane summary) but with different escape sequences. Without it,
+  # we would get multiple hits for the same error.
+  #
+  # See discussion at
+  # https://github.com/wordpress-mobile/WordPress-iOS/pull/19553#discussion_r1017743950
+  cat $LOGS \
+    | sed -ne 's/\[.*\].*genstrings: error: /- /p' \
     | sed -e $'s/\x1b\[[0-9;]*m//g' \
     | sort \
     | uniq \

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -29,7 +29,7 @@ if [[ $EXIT_CODE -ne 0 ]]; then
   # Strings generation finished with errors, extract the errors in an easy-to-find section
   echo "+++ :x: Strings Generation Failed"
   ERRORS=errors.txt
-  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`*LocalizedStrings\` calls:" | tee $ERRORS
+  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`{NS,App}LocalizedStrings\` calls:" | tee $ERRORS
   echo '' >> $ERRORS
   # Print the errors inline.
   #

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -28,8 +28,8 @@ set -e
 if [[ $EXIT_CODE -ne 0 ]]; then
   # Strings generation finished with errors, extract the errors in an easy-to-find section
   echo "+++ :x: Strings Generation Failed"
-  ERRORS=errors.txt
-  printf "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`{NS,App}LocalizedStrings\` calls:\n\n" | tee $ERRORS
+  ERRORS_FILE=errors.txt
+  printf "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`{NS,App}LocalizedStrings\` calls:\n\n" | tee $ERRORS_FILE
   # Print the errors inline.
   #
   # Notice the second `sed` call that removes the ANSI escape sequences that
@@ -45,9 +45,9 @@ if [[ $EXIT_CODE -ne 0 ]]; then
     | sed -e $'s/\x1b\[[0-9;]*m//g' \
     | sort \
     | uniq \
-    | tee -a $ERRORS
+    | tee -a $ERRORS_FILE
   # Annotate the build with the errors
-  cat $ERRORS | buildkite-agent annotate --style error --context genstrings
+  cat $ERRORS_FILE | buildkite-agent annotate --style error --context genstrings
 fi
 
 exit $EXIT_CODE

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -21,7 +21,11 @@ echo "--- :sleuth_or_spy: Lint Apple Localized Strings Format"
 LOGS=logs.txt
 set +e
 set -o pipefail
-bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
+if [[ $# -eq 0 ]]; then
+  bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
+else
+  bundle exec fastlane "$@" | tee $LOGS
+fi
 EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
Extracts the script developed in https://github.com/wordpress-mobile/WordPress-iOS/pull/19553 to this plugin so it can be used across multiple repos and iterated upon in isolation.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/19624 for a live demo of the happy behavior and https://github.com/wordpress-mobile/WordPress-iOS/pull/19544 for when it catches errors.