### PR TITLE
Show `Gemfile.lock` diff when `validate_gemfile_lock` fails

### DIFF
--- a/bin/validate_gemfile_lock
+++ b/bin/validate_gemfile_lock
@@ -3,9 +3,9 @@
 # We always need to run `bundle install` first, otherwise we can't compare
 bundle install
 
-if git status | grep modified | grep -q Gemfile.lock; then 
-	echo "Error: Gemfile.lock is not in sync – please run \`bundle install\` and commit your changes"
-	exit 1
+if git status | grep modified | grep -q Gemfile.lock; then
+  echo "Error: Gemfile.lock is not in sync – please run \`bundle install\` and commit your changes"
+  exit 1
 fi
 
 echo "Gemfile.lock is in sync"

--- a/bin/validate_gemfile_lock
+++ b/bin/validate_gemfile_lock
@@ -5,6 +5,10 @@ bundle install
 
 if git status | grep modified | grep -q Gemfile.lock; then
   echo "Error: Gemfile.lock is not in sync – please run \`bundle install\` and commit your changes"
+  echo ''
+  echo 'Gemfile.lock diff:'
+  echo ''
+  git diff Gemfile.lock
   exit 1
 fi
 


### PR DESCRIPTION
We recently run in some Intel vs Apple Silicon issues in https://github.com/wordpress-mobile/NSURL-IDN/pull/8. The `Gemfile.lock` validation failed in CI, but running `bundle install` locally didn't change the `Gemfile.lock`.

To understand the failure better, I made the command print the `Gemfile.lock` diff.

You can see it in action [here](https://buildkite.com/automattic/nsurl-idn/builds/5#0184c008-757a-4ce5-bc51-e390f70d90e1).

![image](https://user-images.githubusercontent.com/1218433/204535735-21ca8faf-b833-424e-9fb8-a97985c2822b.png)

