### PR TITLE
Fix `annotate_test_failures` for flaky retries which ultimately succeed

### DIFF
--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -17,28 +17,46 @@ end
 file = File.open(junit_path)
 xmldoc = REXML::Document.new(file)
 
+# Here's how report.junit XML files look like for failure vs success:
+#
+# <testcase classname='WordPressTest.MediaServiceTests' name='testDeletingLocalMediaThatDoesntExistInCoreData'>
+#   <failure message='Asynchronous wait failed: Exceeded timeout of 0.1 seconds, with unfulfilled expectations: &quot;The delete call succeeds even if the media object isn&apos;t saved.&quot;.'>&lt;unknown&gt;:0</failure>
+# </testcase>
+# <testcase classname='WordPressTest.MediaServiceTests' name='testDeletingLocalMediaThatDoesntExistInCoreData' time='0.145'/>
+#
 failures = []
 REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
-  failure = testcase.elements['failure']
-  failures.append <<~ENTRY
-  <details><summary><tt>#{testcase['name']}</tt> in <tt>#{testcase['classname']}</tt></summary>
-  
-  #{failure['message']}
+  test_class = testcase['classname']
+  test_name = testcase['name']
+  failure_node = testcase.elements['failure']
+  failure_message = failure_node['message']
 
-  ```
-  #{failure.text}
-  ```
-  </details>
-  ENTRY
+  # Find all nodes that are about the same test, to detect false positives
+  # (in case there were multiple retries of the same flaky test with the last one ultimately passing)
+  retries = testcase.parent.get_elements("testcase[@classname='#{testcase['classname']}' and @name='#{testcase['name']}']")
+  if retries.last.elements['failure']
+    failures.append <<~ENTRY
+      <details><summary><tt>#{test_name}</tt> in <tt>#{test_class}</tt></summary>
+      #{failure_message}
+  
+      ```
+      #{failure_node.text}
+      ```
+      </details>
+    ENTRY
+  else
+    puts "- Note: Flaky test \`#{test_class}`.`#{test_name}`: #{failure_message}"
+  end
 end
 
 if failures.empty?
-  puts "No test failure found. Removing any previous `#{title}` Buildkite annotation if any."
+  puts "No test failure found (after eliminating intermediate failed retries). Removing any previous `#{title}` Buildkite annotation if any."
   system('buildkite-agent', 'annotation', 'remove', '--context', title)
   exit 0 # We don't want to fail if the `annotation remove` command failed because there was no previous annotation
 else
-  puts "Found #{failures.count} test failure(s). Reporting them as a `#{title}` Buildkite annotation."
+  puts "Ultimately found #{failures.count} real test failure(s). Reporting them as a `#{title}` Buildkite annotation."
   markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
+  puts markdown
   system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
   exit $?.exitstatus
 end

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -5,6 +5,10 @@
 #
 require 'rexml/document'
 
+###################
+# Parse arguments
+###################
+
 junit_path = ARGV.first || File.join('build', 'results', 'report.junit')
 title = ENV.fetch('BUILDKITE_LABEL', 'Tests')
 
@@ -14,8 +18,9 @@ unless File.exist?(junit_path)
   exit 0
 end
 
-file = File.open(junit_path)
-xmldoc = REXML::Document.new(file)
+###################
+# Helper methods
+###################
 
 # Here's how report.junit XML files look like for failure vs success:
 #
@@ -24,39 +29,91 @@ xmldoc = REXML::Document.new(file)
 # </testcase>
 # <testcase classname='WordPressTest.MediaServiceTests' name='testDeletingLocalMediaThatDoesntExistInCoreData' time='0.145'/>
 #
-failures = []
-REXML::XPath.each(xmldoc, '//testcase[failure]') do |testcase|
-  test_class = testcase['classname']
-  test_name = testcase['name']
-  failure_node = testcase.elements['failure']
-  failure_message = failure_node['message']
+class TestFailure
+  attr_reader :classname, :name, :message, :details
+  attr_accessor :count
 
-  # Find all nodes that are about the same test, to detect false positives
-  # (in case there were multiple retries of the same flaky test with the last one ultimately passing)
-  retries = testcase.parent.get_elements("testcase[@classname='#{testcase['classname']}' and @name='#{testcase['name']}']")
-  if retries.last.elements['failure']
-    failures.append <<~ENTRY
-      <details><summary><tt>#{test_name}</tt> in <tt>#{test_class}</tt></summary>
-      #{failure_message}
-  
+  def initialize(node)
+    @classname = node['classname']
+    @name = node['name']
+    failure_node = node.elements['failure']
+    @message = failure_node['message']
+    @details = failure_node.text
+    @count = 1
+  end
+
+  def to_s
+    times = @count > 1 ? " (#{@count} times)" : ''
+    <<~ENTRY
+      <details><summary><tt>#{@name}</tt> in <tt>#{@classname}</tt>#{times}</summary>
+      #{@message}
+
       ```
-      #{failure_node.text}
+      #{@details}
       ```
       </details>
     ENTRY
-  else
-    puts "- Note: Flaky test \`#{test_class}`.`#{test_name}`: #{failure_message}"
+  end
+
+  def key
+    "#{@classname}.#{@name}"
+  end
+
+  def ultimately_succeeds?(parent_node:)
+    all_same_test_nodes = parent_node.get_elements("testcase[@classname='#{@classname}' and @name='#{@name}']")
+    !all_same_test_nodes.last.elements['failure'] # If last node found for that test doesn't have a <failure> child, then test ultimately succeeded.
+  end
+
+  def ==(other)
+    @classname == other.classname && @name == other.name && @message == other.message && @details == other.details
   end
 end
 
-if failures.empty?
-  puts "No test failure found (after eliminating intermediate failed retries). Removing any previous `#{title}` Buildkite annotation if any."
-  system('buildkite-agent', 'annotation', 'remove', '--context', title)
-  exit 0 # We don't want to fail if the `annotation remove` command failed because there was no previous annotation
-else
-  puts "Ultimately found #{failures.count} real test failure(s). Reporting them as a `#{title}` Buildkite annotation."
-  markdown = "\#\#\#\# #{title}: #{failures.length} failure(s)\n\n" + failures.join("\n")
-  puts markdown
-  system('buildkite-agent', 'annotate', markdown, '--style', 'error', '--context', title)
-  exit $?.exitstatus
+# Add a test_failure into a given array, or increment its count if it already exists
+#
+def record(test_failure, into:)
+  existing = into.find { |f| f == test_failure }
+  if existing.nil?
+    into.append(test_failure)
+  else
+    existing.count += 1
+  end
 end
+
+# Given a list of failures for a given step and state, update the corresponding annotation
+#
+def update_annotation(title, list, style, state)
+  annotation_context = "#{title} (#{state})"
+  if list.empty?
+    puts "No test #{state}. Removing any previous `#{annotation_context}` Buildkite annotation if any.\n\n"
+    system('buildkite-agent', 'annotation', 'remove', '--context', annotation_context)
+  else
+    tests_count = list.map(&:key).uniq.count # Count the number of tests that failed, even if some tests might have multiple assertion failures
+    puts "#{tests_count} test(s) #{state} (#{list.count} distinct assertion failures in total). Reporting them as a `#{annotation_context}` Buildkite #{style} annotation.\n\n"
+    markdown = "\#\#\#\# #{title}: #{tests_count} tests #{state} (#{list.count} distinct assertion failure(s) in total)\n\n" + list.map(&:to_s).join("\n")
+    puts markdown
+    system('buildkite-agent', 'annotate', markdown, '--style', style, '--context', annotation_context)
+  end
+end
+
+###################
+# Main
+###################
+
+file = File.open(junit_path)
+xmldoc = REXML::Document.new(file)
+
+failures = []
+flakies = []
+REXML::XPath.each(xmldoc, '//testcase[failure]') do |node|
+  test_failure = TestFailure.new(node)
+
+  if test_failure.ultimately_succeeds?(parent_node: node.parent)
+    record(test_failure, into: flakies)
+  else
+    record(test_failure, into: failures)
+  end
+end
+
+update_annotation(title, failures, 'error', 'have failed')
+update_annotation(title, flakies, 'warning', 'were flaky')


### PR DESCRIPTION
## What?

Fixes `annotate_test_failures` command, to ignore cases of flaky retries which ultimately succeeded.

This bug was the cause for some CI builds to still get an annotation mentioning test failures… even when the corresponding CI step ended up green (See [this example build](https://buildkite.com/automattic/wordpress-ios/builds/12940)):

<img width="1160" alt="test-failure-annotation-but-step-green" src="https://user-images.githubusercontent.com/216089/224157678-0b9564eb-db68-4c71-8e1d-573e0b00d92e.png">

_(cc @mokagio & @crazytonyli  as I talked about this bug very recently with both of you, in P2s and PR comments respectively)_

## Why?

When a flaky test failed but Xcode is configured to auto-retry tests multiple times on failure, all the intermediate failures are recorded in the `report.junit` alongside the final success (if any). For example this is an extract of such `.junit` report:

```xml
    <testcase classname='WordPressTest.TenorDataSourceTests' name='testDataSourceReceivesRequestedCount'>
      <failure message='Asynchronous wait failed: Exceeded timeout of 2 seconds, with unfulfilled expectations: &quot;Waiting&quot;.'>&lt;unknown&gt;:0</failure>
    </testcase>
    <testcase classname='WordPressTest.TenorDataSourceTests' name='testDataSourceReceivesRequestedCount'>
      <failure message='XCTAssertEqual failed: (&quot;Optional(0)&quot;) is not equal to (&quot;Optional(3)&quot;)'>WordPress/WordPressTest/MediaPicker/Tenor/TenorDataSouceTests.swift:37</failure>
    </testcase>
    <testcase classname='WordPressTest.TenorDataSourceTests' name='testDataSourceReceivesRequestedCount' time='1.042'/>
```

The previous version of our script were not smart enough to detect that, and simply extracted all `testcase` nodes that had a `failure` subnode, and built the annotation with the list of found failures from that. Which is why it erroneously included the flaky failures

## How?

To solve this, during the iteration on the `testcase[failure]` node candidates, we are now finding all the sibling nodes to that `testcase` which happens to have the same `classname` and `name` attributes, i.e. nodes reporting all the assertion failures for the same test. This list will thus include the current candidate being iterated on, but also potentially all other retries of the same test.

Once we got that list of nodes, we check if the last one of those nodes ends up being a failure or success XML node:
 - If it ended up in success, that means this was a flaky test that ultimately ended up being marked green by Xcode and was considered passing (even if it failed first and was retried)
 - While if that last instance ended up with a failure, that means the test never succeeded even during potential subsequent retries, so that's a true failure that needs reporting

## Testing

### WPiOS Demo build with ❌ failed + ⚠️ flaky tests

 - Check [this Buildkite build](https://buildkite.com/automattic/wordpress-ios/builds/13022) — which corresponds to [the build of the test branch I created in WPiOS specifically to create flaky tests and point to this branch of the plugin](https://github.com/wordpress-mobile/WordPress-iOS/compare/bcfad40714)
 - Confirm that the build is red / marked as failed
 - Confirm that both the error and warning annotations are present under the "All Jobs" tab, and that both look ok
    - Note: if Buildkite shows you the "Issues" tab instead of "All Jobs" tab by default, that will only show you the error annotation; be sure to check the "All Jobs" tab to see the warning annotation too.

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/216089/224430604-141302d1-28a8-4b59-a2f7-d3b95fe227e0.png">

### WPiOS Demo build with ⚠️ only flaky tests

 - Check [this Buildkite build](https://buildkite.com/automattic/wordpress-ios/builds/13026) — which [disables all failing tests and only keep flaky ones](https://github.com/wordpress-mobile/WordPress-iOS/commit/bdc248c9fe854804392b9323c43abd71e9087d70)
 - Confirm that the build is green / passed
 - Confirm that there is no error annotation but only a warning annotation, and that it looks ok

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/216089/224435111-a9ceb133-31b2-4ab5-be09-2274e4f7ce2c.png">

### WPiOS Demo build with ❌ only failed tests

 - Check [this Buildkite build](https://buildkite.com/automattic/wordpress-ios/builds/13024) — which [disables all flaky tests and only keep failing ones](https://github.com/wordpress-mobile/WordPress-iOS/commit/2dbc20cc30489f66ed992695913faed9184922f2)
 - Confirm that the build is red / marked as failed
 - Confirm that there is no warning annotation but only an error annotation, and that it looks ok

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/216089/224430506-5cf1b5c3-9fcd-4eb9-bf52-5a398788dfcb.png">

