### PR TITLE
`annotate_test_failure`: Absorb potential failure in annotation removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Prevent `annotate_test_failures` to print a misleading red error message when trying to remove previous annotation. [#50]
 
 ### Internal Changes
 
-- Added this changelog file [#49]
+- Added this changelog file. [#49]

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -4,6 +4,7 @@
 #   annotate_test_failures [junit-file-path]
 #
 require 'rexml/document'
+require 'shellwords'
 
 ###################
 # Parse arguments
@@ -86,7 +87,7 @@ def update_annotation(title, list, style, state)
   annotation_context = "#{title} (#{state})"
   if list.empty?
     puts "No test #{state}. Removing any previous `#{annotation_context}` Buildkite annotation if any.\n\n"
-    system('buildkite-agent', 'annotation', 'remove', '--context', annotation_context)
+    system("buildkite-agent annotation remove --context #{annotation_context.shellescape} 2>/dev/null || true")
   else
     tests_count = list.map(&:key).uniq.count # Count the number of tests that failed, even if some tests might have multiple assertion failures
     puts "#{tests_count} test(s) #{state} (#{list.count} distinct assertion failures in total). Reporting them as a `#{annotation_context}` Buildkite #{style} annotation.\n\n"

--- a/tests/environment.bats
+++ b/tests/environment.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load '/usr/local/lib/bats/load.bash'
+load "$BATS_PLUGIN_PATH/load.bash"
 
 fail() {
   echo "Failure: $1"


### PR DESCRIPTION
This is to avoid a misleading red error log to be output if no annotation existed when we tried to remove it.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/20378

## Testing

 - This fix is being tested in [this CI build of WPiOS](https://buildkite.com/automattic/wordpress-ios/builds/13716).

## Next Steps

 - Release a new version `2.15.1`
 - Update [this WPiOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20378) to point to the new version/tag (in _all_ `.yml` pipelines) once its released.

## Checklist

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
