### PR TITLE
Re-implement `comment_on_pr` to use `curl` instead of `gh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,3 +47,4 @@ _None._
 ### Internal Changes
 
 - Added this changelog file. [#49]
+- Re-implement the `comment_on_pr` script. [#51]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ _None._
 
 ### New Features
 
-_None._
+- Add a new `github_api` utlity to make API requests to GitHub.com or Github Enterprise instances. [#51]
+- Extend the `comment_on_pr` utility to update or delete the existing comment. [#51]
 
 ### Bug Fixes
 
@@ -48,4 +49,3 @@ _None._
 
 - Added this changelog file. [#49]
 - Re-implement the `comment_on_pr` utility to use `curl` instead of `gh`. [#51]
-- Extend the `comment_on_pr` utility to update or delete the existing comment. [#51]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,4 +47,4 @@ _None._
 ### Internal Changes
 
 - Added this changelog file. [#49]
-- Re-implement the `comment_on_pr` script. [#51]
+- Re-implement the `comment_on_pr` utility to use `curl` instead of `gh`. [#51]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,4 @@ _None._
 
 - Added this changelog file. [#49]
 - Re-implement the `comment_on_pr` utility to use `curl` instead of `gh`. [#51]
+- Extend the `comment_on_pr` utility to update or delete the existing comment. [#51]

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -63,14 +63,13 @@ case "$#" in
     *) echo "Error: invalid comment argument"; exit 1 ;;
 esac
 
+export GITHUB_TOKEN="$arg_github_token"
+
 github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
-issues_endpoint="https://api.github.com/repos/${github_user}/${github_repo}/issues"
+issues_endpoint="repos/${github_user}/${github_repo}/issues"
 
-curl -s --fail -o /dev/null \
-    -H "Authorization: token ${arg_github_token}" \
-    -H "Accept: application/vnd.github+json" \
-    "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail -o /dev/null \
     || (echo "The GitHub token is invalid" && exit 1)
 
 # Find the existing PR comment
@@ -82,10 +81,7 @@ if [[ -n "$opt_comment_id" ]]; then
 
     # Do not change this variable value, it's used to identify the comments posted by this utility.
     comment_body_id="<!-- DO NOT REMOVE ci-toolkit-comment-identifier: $opt_comment_id -->"
-    existing_comment_id="$(curl -s \
-        -H "Authorization: token ${arg_github_token}" \
-        -H "Accept: application/vnd.github+json" \
-        "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+    existing_comment_id="$(github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
         | jq ".[] | select(.body | contains(\"$comment_body_id\")) | .id")"
 
     # When comment id is provided without a comment body, delete the existing comment.
@@ -100,10 +96,8 @@ fi
 # Delete the existing comment if needed
 if [[ -n "$existing_comment_id" && "$opt_if_exist" == "delete" ]]; then
     echo "Delete the existing comment containing $existing_comment_id"
-    curl -s --fail-with-body -X DELETE \
-        -H "Authorization: token ${arg_github_token}" \
-        -H "Accept: application/vnd.github+json" \
-        "$issues_endpoint/comments/$existing_comment_id"
+    github_api "$issues_endpoint/comments/$existing_comment_id" \
+        --fail-with-body -X DELETE
 fi
 
 # Construct the comment JSON
@@ -112,25 +106,22 @@ $comment_body_id
 $arg_pr_comment
 EOF
 )
-json_payload=$(jq --null-input --arg body "$comment_body" '{body: $body}')
+json_payload=$(jq -c --null-input --arg body "$comment_body" '{body: $body}')
 
 if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
     echo "Update the existing comment: $existing_comment_id"
-    curl -s --fail-with-body -X PATCH \
-        -H "Authorization: token ${arg_github_token}" \
+    github_api "$issues_endpoint/comments/$existing_comment_id" \
+        --fail-with-body -X PATCH \
         -H "Content-Type: application/json" \
-        -H "Accept: application/vnd.github+json" \
-        -d "${json_payload}" \
-        "$issues_endpoint/comments/$existing_comment_id"
+        -d "${json_payload}"
+
 elif [[ -n "$arg_pr_comment" ]]; then
     echo "Post a new comment"
-    curl -s --fail-with-body -X POST \
-        -H "Authorization: token ${arg_github_token}" \
+    github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+        --fail-with-body -X POST \
         -H "Content-Type: application/json" \
-        -H "Accept: application/vnd.github+json" \
-        -d "${json_payload}" \
-        "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments"
+        -d "${json_payload}"
 else
-    # No comment body was given in CLI, so do nothing
-    echo "No comment to post"
+    # No comment body was given in CLI, so no new comment to post
+    echo "No new comment to post"
 fi

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -7,8 +7,19 @@
 # 2. The GitHub token to use to post the comment
 
 # Check dependencies and print their versions for diagnosis purposes
-jq --version
-curl --version
+cat <<EOF
+> jq --version
+$(jq --version)
+
+> curl --version
+$(curl --version)
+
+EOF
+
+if [[ "${BUILDKITE_PULL_REQUEST:-invalid}" == "invalid" ]]; then
+    echo "Error: this tool can only be called from a Buildkite PR job"
+    exit 1
+fi
 
 if [[ -f "$1" ]]; then
     PR_COMMENT=$(cat "$1")

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -47,6 +47,10 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 case "$#" in
+    0)
+        arg_pr_comment=""
+        arg_github_token=${GITHUB_TOKEN}
+        ;;
     1)
         arg_pr_comment=""
         arg_github_token=$1

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -39,7 +39,7 @@ fi
 # Default options
 opt_comment_id=""
 opt_if_exist="update"
-opt_github_token="${GITHUB_TOKEN-:}"
+opt_github_token="${GITHUB_TOKEN:-}"
 
 # If there are two arguments and they don't start with an option, then we assume
 # this utility is called in the deprecated way: comment_on_pr <comment> <github-token>
@@ -74,7 +74,7 @@ else
                 arg_pr_comment="$1"
             fi
             ;;
-        *) echo "Error: invalid comment argument"; exit 1 ;;
+        *) echo "Error: too many arguments"; exit 1 ;;
     esac
 fi
 
@@ -129,7 +129,6 @@ if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
         --fail-with-body -X PATCH \
         -H "Content-Type: application/json" \
         -d "${json_payload}"
-
 elif [[ -n "$arg_pr_comment" ]]; then
     echo "Post a new comment"
     github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -84,10 +84,14 @@ github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 issues_endpoint="repos/${github_user}/${github_repo}/issues"
 
-all_pr_comments=$(
-    github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail \
-    || (>&2 echo "Error: Failed to use the GitHub token to retreive PR comments. Please double check the GitHub token is valid and has permission to read and write PR comments in ${github_user}/${github_repo} repo." && exit 1)
-)
+pr_comments_file=$(mktemp)
+
+if ! github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail-with-body --output "$pr_comments_file";
+then
+    echo "Error: Failed to use the GitHub token to retreive PR comments."
+    [[ -f "$pr_comments_file" ]] && cat "$pr_comments_file"
+    exit 1
+fi
 
 # Find the existing PR comment
 if [[ -n "$opt_comment_id" ]]; then
@@ -98,8 +102,7 @@ if [[ -n "$opt_comment_id" ]]; then
 
     # Do not change this variable value, it's used to identify the comments posted by this utility.
     comment_body_id="<!-- DO NOT REMOVE ci-toolkit-comment-identifier: $opt_comment_id -->"
-    existing_comment_id="$(echo "$all_pr_comments" \
-        | jq ".[] | select(.body | contains(\"$comment_body_id\")) | .id")"
+    existing_comment_id="$(jq --arg comment_body_id "$comment_body_id" '.[] | select(.body | contains($comment_body_id)) | .id' "$pr_comments_file")"
 
     # When comment id is provided without a comment body, delete the existing comment.
     if [[ -z "$arg_pr_comment" ]]; then

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -84,8 +84,10 @@ github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 issues_endpoint="repos/${github_user}/${github_repo}/issues"
 
-github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail -o /dev/null \
-    || (echo "The GitHub token is invalid" && exit 1)
+all_pr_comments=$(
+    github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail \
+    || (>&2 echo "Error: The GitHub token is invalid" && exit 1)
+)
 
 # Find the existing PR comment
 if [[ -n "$opt_comment_id" ]]; then
@@ -96,7 +98,7 @@ if [[ -n "$opt_comment_id" ]]; then
 
     # Do not change this variable value, it's used to identify the comments posted by this utility.
     comment_body_id="<!-- DO NOT REMOVE ci-toolkit-comment-identifier: $opt_comment_id -->"
-    existing_comment_id="$(github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+    existing_comment_id="$(echo "$all_pr_comments" \
         | jq ".[] | select(.body | contains(\"$comment_body_id\")) | .id")"
 
     # When comment id is provided without a comment body, delete the existing comment.

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -31,7 +31,7 @@ $(curl --version)
 
 EOF
 
-if [[ "${BUILDKITE_PULL_REQUEST:-invalid}" == "invalid" ]]; then
+if [[ ! "${BUILDKITE_PULL_REQUEST:-invalid}" =~ ^[0-9]+$ ]]; then
     echo "Error: this tool can only be called from a Buildkite PR job"
     exit 1
 fi

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -7,12 +7,13 @@
 #
 # Examples:
 #
-#    # Post a new comment which can be uniqly identifiered by the given comment id,
+#    # Post a new comment which can be uniquely identified by the given comment id,
 #    # or update the existing comment that's associated with the given comment id.
-#    # You can choose to delete the existing comment if it exists by passing `--if-exist delete`.
+#    # By default, the existing comment will be updated. You can choose to delete
+#    # the existing comment by passing `--if-exist delete`.
 #    comment_on_pr --id comment-id [--if-exist update|delete] "This is a comment"
 #
-#    # Delete the comment associated with the given comment id
+#    # Delete the comment associated with the given comment id by passing an empty comment
 #    comment_on_pr --id comment-id [--if-exist delete]
 #
 #    # Deprecated: Post a new comment to the PR

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -86,7 +86,7 @@ issues_endpoint="repos/${github_user}/${github_repo}/issues"
 
 all_pr_comments=$(
     github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" --fail \
-    || (>&2 echo "Error: The GitHub token is invalid" && exit 1)
+    || (>&2 echo "Error: Failed to use the GitHub token to retreive PR comments. Please double check the GitHub token is valid and has permission to read and write PR comments in ${github_user}/${github_repo} repo." && exit 1)
 )
 
 # Find the existing PR comment

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -43,7 +43,7 @@ opt_github_token="${GITHUB_TOKEN:-}"
 
 # If there are two arguments and they don't start with an option, then we assume
 # this utility is called in the deprecated way: comment_on_pr <comment> <github-token>
-if [[ $# == 2 && "$1" != "--" ]]; then
+if [[ $# == 2 && "$1" != "--"* ]]; then
     if [[ -f "$1" ]]; then
         arg_pr_comment=$(cat "$1")
     else

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -3,17 +3,20 @@
 # This script is used to comment on a pull request, and must be run in a buldkite PR step.
 #
 # Usage:
+#    [GITHUB_TOKEN=<token>] comment_on_pr [--id <comment-id>] [--if-exist update|delete] [--github-token <token>] <comment>
 #
-#    # Post a new comment to the PR
-#    comment_on_pr "This is a comment" <github-token>
+# Examples:
 #
 #    # Post a new comment which can be uniqly identifiered by the given comment id,
 #    # or update the existing comment that's associated with the given comment id.
 #    # You can choose to delete the existing comment if it exists by passing `--if-exist delete`.
-#    comment_on_pr --id comment-id "This is a comment" [--if-exist update|delete] <github-token>
+#    comment_on_pr --id comment-id [--if-exist update|delete] "This is a comment"
 #
 #    # Delete the comment associated with the given comment id
-#    comment_on_pr --id comment-id <github-token>
+#    comment_on_pr --id comment-id [--if-exist delete]
+#
+#    # Deprecated: Post a new comment to the PR
+#    comment_on_pr "This is a comment" <github-token>
 #
 # Please note the comment argument can be a path to a file containing the comment, or a markdown.
 
@@ -35,39 +38,46 @@ fi
 # Default options
 opt_comment_id=""
 opt_if_exist="update"
+opt_github_token="${GITHUB_TOKEN-:}"
 
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-        --id) opt_comment_id="$2"; shift ;;
-        --if-exist) opt_if_exist="$2"; shift ;;
-        --*) echo "Unknown option: $1"; exit 1 ;;
-        *) break ;;
+# If there are two arguments and they don't start with an option, then we assume
+# this utility is called in the deprecated way: comment_on_pr <comment> <github-token>
+if [[ $# == 2 && "$1" != "--" ]]; then
+    if [[ -f "$1" ]]; then
+        arg_pr_comment=$(cat "$1")
+    else
+        arg_pr_comment="$1"
+    fi
+
+    opt_github_token=$2
+else
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            --id) opt_comment_id="$2"; shift ;;
+            --if-exist) opt_if_exist="$2"; shift ;;
+            --github-token) opt_github_token="$2"; shift ;;
+            --*) echo "Unknown option: $1"; exit 1 ;;
+            *) break ;;
+        esac
+        shift
+    done
+
+    case "$#" in
+        0)
+            arg_pr_comment=""
+            ;;
+        1)
+            if [[ -f "$1" ]]; then
+                arg_pr_comment=$(cat "$1")
+            else
+                arg_pr_comment="$1"
+            fi
+            ;;
+        *) echo "Error: invalid comment argument"; exit 1 ;;
     esac
-    shift
-done
+fi
 
-case "$#" in
-    0)
-        arg_pr_comment=""
-        arg_github_token=${GITHUB_TOKEN}
-        ;;
-    1)
-        arg_pr_comment=""
-        arg_github_token=$1
-        ;;
-    2)
-        if [[ -f "$1" ]]; then
-            arg_pr_comment=$(cat "$1")
-        else
-            arg_pr_comment="$1"
-        fi
-
-        arg_github_token=$2
-        ;;
-    *) echo "Error: invalid comment argument"; exit 1 ;;
-esac
-
-export GITHUB_TOKEN="$arg_github_token"
+export GITHUB_TOKEN="$opt_github_token"
 
 github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -2,9 +2,20 @@
 
 # This script is used to comment on a pull request, and must be run in a buldkite PR step.
 #
-# It takes two arguments:
-# 1. The comment to post, or the path to a file containing the comment
-# 2. The GitHub token to use to post the comment
+# Usage:
+#
+#    # Post a new comment to the PR
+#    comment_on_pr "This is a comment" <github-token>
+#
+#    # Post a new comment which can be uniqly identifiered by the given comment id,
+#    # or update the existing comment that's associated with the given comment id.
+#    # You can choose to delete the existing comment if it exists by passing `--if-exist delete`.
+#    comment_on_pr --id comment-id "This is a comment" [--if-exist update|delete] <github-token>
+#
+#    # Delete the comment associated with the given comment id
+#    comment_on_pr --id comment-id <github-token>
+#
+# Please note the comment argument can be a path to a file containing the comment, or a markdown.
 
 # Check dependencies and print their versions for diagnosis purposes
 cat <<EOF
@@ -21,24 +32,95 @@ if [[ "${BUILDKITE_PULL_REQUEST:-invalid}" == "invalid" ]]; then
     exit 1
 fi
 
-if [[ -f "$1" ]]; then
-    PR_COMMENT=$(cat "$1")
-else
-    PR_COMMENT="$1"
-fi
+# Default options
+opt_comment_id=""
+opt_if_exist="update"
 
-GITHUB_TOKEN=$2
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --id) opt_comment_id="$2"; shift ;;
+        --if-exist) opt_if_exist="$2"; shift ;;
+        --*) echo "Unknown option: $1"; exit 1 ;;
+        *) break ;;
+    esac
+    shift
+done
+
+case "$#" in
+    1)
+        arg_pr_comment=""
+        arg_github_token=$1
+        ;;
+    2)
+        if [[ -f "$1" ]]; then
+            arg_pr_comment=$(cat "$1")
+        else
+            arg_pr_comment="$1"
+        fi
+
+        arg_github_token=$2
+        ;;
+    *) echo "Error: invalid comment argument"; exit 1 ;;
+esac
 
 GITHUB_URL="${BUILDKITE_PULL_REQUEST_REPO%.git}"
 GITHUB_USER=$(basename "$(dirname "$GITHUB_URL")")
 GITHUB_REPO=$(basename "$GITHUB_URL")
+issues_endpoint="https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues"
 
-JSON_PAYLOAD=$(jq --null-input --arg body "$PR_COMMENT" '{body: $body}')
+# Find the existing PR comment
+if [[ -n "$opt_comment_id" ]]; then
+    # Do not change this variable value, it's used to identify the comments posted by this utility.
+    comment_body_id="<!-- DO NOT REMOVE ci-toolkit-comment-identifier: $opt_comment_id -->"
+    existing_comment_id="$(curl -s \
+        -H "Authorization: token ${arg_github_token}" \
+        -H "Accept: application/vnd.github+json" \
+        "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+        | jq ".[] | select(.body | contains(\"$comment_body_id\")) | .id")"
 
-curl -s -X POST \
-    --fail-with-body \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -H "Accept: application/vnd.github+json" \
-    -d "${JSON_PAYLOAD}" \
-    "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues/${BUILDKITE_PULL_REQUEST}/comments"
+    # When comment id is provided without a comment body, delete the existing comment.
+    if [[ -z "$arg_pr_comment" ]]; then
+        opt_if_exist="delete"
+    fi
+else
+    comment_body_id=""
+    existing_comment_id=""
+fi
+
+# Delete the existing comment if needed
+if [[ -n "$existing_comment_id" && "$opt_if_exist" == "delete" ]]; then
+    echo "Delete the existing comment containing $existing_comment_id"
+    curl -s --fail-with-body -X DELETE \
+        -H "Authorization: token ${arg_github_token}" \
+        -H "Accept: application/vnd.github+json" \
+        "$issues_endpoint/comments/$existing_comment_id"
+fi
+
+# Construct the comment JSON
+comment_body=$(cat <<EOF
+$comment_body_id
+$arg_pr_comment
+EOF
+)
+json_payload=$(jq --null-input --arg body "$comment_body" '{body: $body}')
+
+if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
+    echo "Update the existing comment: $existing_comment_id"
+    curl -s --fail-with-body -X PATCH \
+        -H "Authorization: token ${arg_github_token}" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/vnd.github+json" \
+        -d "${json_payload}" \
+        "$issues_endpoint/comments/$existing_comment_id"
+elif [[ -n "$arg_pr_comment" ]]; then
+    echo "Post a new comment"
+    curl -s --fail-with-body -X POST \
+        -H "Authorization: token ${arg_github_token}" \
+        -H "Content-Type: application/json" \
+        -H "Accept: application/vnd.github+json" \
+        -d "${json_payload}" \
+        "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments"
+else
+    # No comment body was given in CLI, so do nothing
+    echo "No comment to post"
+fi

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -1,14 +1,33 @@
 #!/bin/bash -eu
 
-PR_MESSAGE_FILE=$1
-GITHUB_TOKEN=$2
+# This script is used to comment on a pull request, and must be run in a buldkite PR step.
+#
+# It takes two arguments:
+# 1. The comment to post, or the path to a file containing the comment
+# 2. The GitHub token to use to post the comment
 
-if ! command -v gh &> /dev/null; then
-	brew install gh
+# Check dependencies and print their versions for diagnosis purposes
+jq --version
+curl --version
+
+if [[ -f "$1" ]]; then
+    PR_COMMENT=$(cat "$1")
+else
+    PR_COMMENT="$1"
 fi
 
-FILENAME="/tmp/github-token-$BUILDKITE_BUILD_ID"
-echo "$GITHUB_TOKEN" > "$FILENAME"
+GITHUB_TOKEN=$2
 
-gh auth login --with-token < "$FILENAME"
-gh pr comment --body-file "$PR_MESSAGE_FILE"
+GITHUB_URL="${BUILDKITE_PULL_REQUEST_REPO%.git}"
+GITHUB_USER=$(basename "$(dirname "$GITHUB_URL")")
+GITHUB_REPO=$(basename "$GITHUB_URL")
+
+JSON_PAYLOAD=$(jq --null-input --arg body "$PR_COMMENT" '{body: $body}')
+
+curl -s -X POST \
+    --fail-with-body \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/vnd.github+json" \
+    -d "${JSON_PAYLOAD}" \
+    "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues/${BUILDKITE_PULL_REQUEST}/comments"

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -67,6 +67,12 @@ github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 issues_endpoint="https://api.github.com/repos/${github_user}/${github_repo}/issues"
 
+curl -s --fail -o /dev/null \
+    -H "Authorization: token ${arg_github_token}" \
+    -H "Accept: application/vnd.github+json" \
+    "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
+    || (echo "The GitHub token is invalid" && exit 1)
+
 # Find the existing PR comment
 if [[ -n "$opt_comment_id" ]]; then
     # Do not change this variable value, it's used to identify the comments posted by this utility.

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -75,6 +75,11 @@ curl -s --fail -o /dev/null \
 
 # Find the existing PR comment
 if [[ -n "$opt_comment_id" ]]; then
+    if ! [[ "$opt_comment_id" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+        echo "Error: comment id can only contain alphanumeric characters, dashes and underscores"
+        exit 1
+    fi
+
     # Do not change this variable value, it's used to identify the comments posted by this utility.
     comment_body_id="<!-- DO NOT REMOVE ci-toolkit-comment-identifier: $opt_comment_id -->"
     existing_comment_id="$(curl -s \

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -80,7 +80,7 @@ fi
 
 export GITHUB_TOKEN="$opt_github_token"
 
-github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
+github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO}")")
 github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 issues_endpoint="repos/${github_user}/${github_repo}/issues"
 

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -63,10 +63,9 @@ case "$#" in
     *) echo "Error: invalid comment argument"; exit 1 ;;
 esac
 
-GITHUB_URL="${BUILDKITE_PULL_REQUEST_REPO%.git}"
-GITHUB_USER=$(basename "$(dirname "$GITHUB_URL")")
-GITHUB_REPO=$(basename "$GITHUB_URL")
-issues_endpoint="https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues"
+github_user=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO%.git}")")
+github_repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
+issues_endpoint="https://api.github.com/repos/${github_user}/${github_repo}/issues"
 
 # Find the existing PR comment
 if [[ -n "$opt_comment_id" ]]; then

--- a/bin/github_api
+++ b/bin/github_api
@@ -1,0 +1,40 @@
+#!/bin/bash -eu
+
+# Similar to `gh api <endpoint>`, this utility makes API calls to GitHub.
+#
+# ENVIRONMENT VARIABLES:
+#   GITHUB_TOKEN: Required. The GitHub token to use for authentication.
+#   GH_HOST: Optional. The GitHub host to use. We'll figure out the host from env vars if not set.
+#
+# Usage:
+#   github_api <endpoint> [curl-options]
+#
+# Example:
+#   github_api user # Send API request and print JSON response
+#   github_api user --head # Make a HEAD request and print response headers
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "Missing environment variable GITHUB_TOKEN"
+    exit 1
+fi
+
+github_endpoint="$1"
+shift
+
+github_host=${GH_HOST:-}
+if [[ -z "${github_host}" ]]; then
+    if [[ -n "${BUILDKITE_PULL_REQUEST_REPO:-}" ]]; then
+        github_host=$(echo "$BUILDKITE_PULL_REQUEST_REPO" | awk -F[/:] '{print $4}')
+    else
+        github_host=github.com
+    fi
+fi
+
+if [[ "$github_host" == "github.com" ]]; then
+    url="https://api.github.com/$github_endpoint"
+else
+    url="https://${github_host}/api/v3/$github_endpoint"
+fi
+
+curl -H "Authorization: token ${GITHUB_TOKEN}" -H "Accept: application/vnd.github+json" -s "$@" "$url"
+exit $?

--- a/bin/github_api
+++ b/bin/github_api
@@ -4,7 +4,7 @@
 #
 # ENVIRONMENT VARIABLES:
 #   GITHUB_TOKEN: Required. The GitHub token to use for authentication.
-#   GH_HOST: Optional. The GitHub host to use. We'll figure out the host from env vars if not set.
+#   GH_HOST: Optional. The GitHub host to use. We'll figure out the host from `BUILDKITE_*` env vars if not set.
 #
 # Usage:
 #   github_api <endpoint> [curl-options]


### PR DESCRIPTION
The existing script depends on `gh` and macOS (installing `gh` when it's missing). I've re-implemented to make it compatible to Linux too, as long as `curl` and `jq` are installed.

I recorded this as an internal change, since the interface is backwards compatible.

## Test instructions

Go to this PR's buildkite job page, select a step, and go to the "Environment" tab. Click the "Show export prefix" button and copy the environment variables. Open a terminal on your computer and paste the copied env vars. Invoking this script from your shell session should post a comment to this PR, or fail with an non-zero exist code.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
