### PR TITLE
Add `delete_pr_comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add a new script: `delete_pr_comment --github-token <token> --containing "part of a comment"`. [#52]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add a new script: `delete_pr_comment --github-token <token> --containing "part of a comment"`. [#52]
+- Add a new script: `delete_pr_comment --github-token <token> --containing '<!-- identifier -->'`. [#52]
 
 ### Bug Fixes
 

--- a/bin/delete_pr_comment
+++ b/bin/delete_pr_comment
@@ -6,8 +6,14 @@
 #   delete_pr_comment --github-token <token> --containing "part of a comment"
 
 # Check dependencies and print their versions for diagnosis purposes
-jq --version
-curl --version
+cat <<EOF
+> jq --version
+$(jq --version)
+
+> curl --version
+$(curl --version)
+
+EOF
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do

--- a/bin/delete_pr_comment
+++ b/bin/delete_pr_comment
@@ -1,0 +1,48 @@
+#!/bin/bash -eu
+
+# This script is used to delete comments on a pull request, and must be run in a buldkite PR step.
+#
+# Example:
+#   delete_pr_comment --github-token <token> --containing "part of a comment"
+
+# Check dependencies and print their versions for diagnosis purposes
+jq --version
+curl --version
+
+# Parse command line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --containing) COMMENT_CONTAINING="$2"; shift ;;
+        --github-token) GITHUB_TOKEN="$2"; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+function require_option() {
+    if [[ -z "$2" ]]; then
+        echo "Error: $1 is required"
+        exit 1
+    fi
+}
+
+require_option '--containing' "$COMMENT_CONTAINING"
+require_option '--github-token' "$GITHUB_TOKEN"
+
+GITHUB_URL="${BUILDKITE_PULL_REQUEST_REPO%.git}"
+GITHUB_USER=$(basename "$(dirname "$GITHUB_URL")")
+GITHUB_REPO=$(basename "$GITHUB_URL")
+
+COMMENT_IDS="$(curl -s \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues/${BUILDKITE_PULL_REQUEST}/comments" \
+    | jq ".[] | select(.body | contains(\"$COMMENT_CONTAINING\")) | .id")"
+
+while IFS= read -r comment_id || [[ -n $comment_id ]]; do
+    echo "Delete the comment containing $COMMENT_CONTAINING: $comment_id"
+    curl -s --fail-with-body -X DELETE \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/issues/comments/$comment_id"
+done < <(printf '%s' "$COMMENT_IDS")

--- a/bin/delete_pr_comment
+++ b/bin/delete_pr_comment
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# This script is used to delete comments on a pull request, and must be run in a buldkite PR step.
+# This script is used to delete comments on a pull request, and must be run in a Buildkite PR step.
 #
 # Example:
 #   delete_pr_comment --github-token <token> --containing "part of a comment"

--- a/bin/delete_pr_comment
+++ b/bin/delete_pr_comment
@@ -35,6 +35,11 @@ function require_option() {
 require_option '--containing' "$COMMENT_CONTAINING"
 require_option '--github-token' "$GITHUB_TOKEN"
 
+if [[ "$COMMENT_CONTAINING" != "<!--"*"-->" ]]; then
+    echo "Error: for safety reasons, the '--containing' argument must be a markdown comment: '<!-- comment -->'"
+    exit 1
+fi
+
 GITHUB_URL="${BUILDKITE_PULL_REQUEST_REPO%.git}"
 GITHUB_USER=$(basename "$(dirname "$GITHUB_URL")")
 GITHUB_REPO=$(basename "$GITHUB_URL")


### PR DESCRIPTION
A new script to delete PR comments that contain a given content.

### Test instructions

Go to this PR's buildkite job page, select a step, and go to the "Environment" tab. Click the "Show export prefix" button and copy the environment variables. Open a terminal on your computer and paste the copied env vars. Invoking this script from your shell session should delete comments (or not) based on the `--containing` argument.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
