### PR TITLE
Use `getopts` in `bin/save_cache`

### DIFF
--- a/bin/save_cache
+++ b/bin/save_cache
@@ -4,11 +4,11 @@ if [ -z "${1:-}" ]; then
 	echo "You must pass the file or directory you want to be cached"
 	exit 1
 else
-  CACHE_FILE=$1
+  CACHE_PATH=$1
 fi
 
-if [ ! -f "$CACHE_FILE" ] && [ ! -d "$CACHE_FILE" ]; then
-  echo "$CACHE_FILE should be either a file nor a directory"
+if [ ! -f "$CACHE_PATH" ] && [ ! -d "$CACHE_FILE" ]; then
+  echo "$CACHE_PATH should be either a file nor a directory"
   exit 1
 fi
 
@@ -19,15 +19,15 @@ CACHE_KEY=$2
 if [ -z "$CACHE_KEY" ]; then
 	echo "No cache key provided – automatically deriving one:"
 
-	# if the $CACHE_FILE is a directory, derived the key from the hash of all files within it
-	if [[ -d $CACHE_FILE ]]; then
-		CACHE_KEY=$(hash_directory "$CACHE_FILE")
-		echo "	'$CACHE_FILE' is a directory with the hash $CACHE_KEY"
+	# if the $CACHE_PATH is a directory, derived the key from the hash of all files within it
+	if [[ -d $CACHE_PATH ]]; then
+		CACHE_KEY=$(hash_directory "$CACHE_PATH")
+		echo "	'$CACHE_PATH' is a directory with the hash $CACHE_KEY"
 
-	# if the $CACHE_FILE is a regular file, derive the key from the file's hash
-	elif [[ -f $CACHE_FILE ]]; then
-		CACHE_KEY=$(hash_file "$CACHE_FILE")
-		echo "	'$CACHE_FILE' is a file with the hash $CACHE_KEY"
+	# if the $CACHE_PATH is a regular file, derive the key from the file's hash
+	elif [[ -f $CACHE_PATH ]]; then
+		CACHE_KEY=$(hash_file "$CACHE_PATH")
+		echo "	'$CACHE_PATH' is a file with the hash $CACHE_KEY"
 	fi
 fi
 
@@ -62,9 +62,9 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 		# directory that's being archived. For example, this will save only the
 		# "DIRECTORY_BEING_ARCHIVED" in `/User/builder/DIRECTORY_BEING_ARCHIVED`
 		# instead of also creating `/User/builder` when extracting the archive
-		tar -czf "$CACHE_KEY" --directory "$CACHE_FILE" .
+		tar -czf "$CACHE_KEY" --directory "$CACHE_PATH" .
 	else
-		tar -czf "$CACHE_KEY" "$CACHE_FILE"
+		tar -czf "$CACHE_KEY" "$CACHE_PATH"
 	fi
 
 	echo "	Uploading"

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -18,7 +18,7 @@ if [ -z "$CACHE_KEY" ]; then
 		echo "	'$CACHE_FILE' is a directory with the hash $CACHE_KEY"
 
 	# if the $CACHE_FILE is a regular file, derive the key from the file's hash
-	elif [[ -f $CACHE_FILE ]]; then  
+	elif [[ -f $CACHE_FILE ]]; then
 		CACHE_KEY=$(hash_file "$CACHE_FILE")
 		echo "	'$CACHE_FILE' is a file with the hash $CACHE_KEY"
 	fi
@@ -52,10 +52,10 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	if [[ "$TAR_CONFIG" == '--use_relative_path_in_tar' ]]; then
 		# This is used by actions such as `install_swiftpm_dependencies`
 		# This configuration allows the tar to not include the full system path of the
-		# directory that's being archived. For example, this will save only the 
-		# "DIRECTORY_BEING_ARCHIVED" in `/User/builder/DIRECTORY_BEING_ARCHIVED` 
+		# directory that's being archived. For example, this will save only the
+		# "DIRECTORY_BEING_ARCHIVED" in `/User/builder/DIRECTORY_BEING_ARCHIVED`
 		# instead of also creating `/User/builder` when extracting the archive
-		tar -czf "$CACHE_KEY" -C "$CACHE_FILE" .		
+		tar -czf "$CACHE_KEY" -C "$CACHE_FILE" .
 	else
 		tar -czf "$CACHE_KEY" "$CACHE_FILE"
 	fi

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -7,6 +7,12 @@ else
   CACHE_FILE=$1
 fi
 
+if [ ! -f "$CACHE_FILE" ] && [ ! -d "$CACHE_FILE" ]; then
+  echo "$CACHE_FILE should be either a file nor a directory"
+  exit 1
+fi
+
+
 CACHE_KEY=$2
 
 # We can automatically derive a cache key if one isn't provided

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,12 +1,13 @@
 #!/bin/bash -eu
 
-CACHE_FILE=$1
-CACHE_KEY=$2
-
-if [ -z "$CACHE_FILE" ]; then
+if [ -z "${1:-}" ]; then
 	echo "You must pass the file or directory you want to be cached"
 	exit 1
+else
+  CACHE_FILE=$1
 fi
+
+CACHE_KEY=$2
 
 # We can automatically derive a cache key if one isn't provided
 if [ -z "$CACHE_KEY" ]; then

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,8 +1,8 @@
 #!/bin/bash -eu
 
 if [ -z "${1:-}" ]; then
-	echo "You must pass the file or directory you want to be cached"
-	exit 1
+  echo "You must pass the file or directory you want to be cached"
+  exit 1
 else
   CACHE_PATH=$1
 fi
@@ -12,23 +12,11 @@ if [ ! -f "$CACHE_PATH" ] && [ ! -d "$CACHE_FILE" ]; then
   exit 1
 fi
 
-
-CACHE_KEY=$2
-
-# We can automatically derive a cache key if one isn't provided
-if [ -z "$CACHE_KEY" ]; then
-	echo "No cache key provided – automatically deriving one:"
-
-	# if the $CACHE_PATH is a directory, derived the key from the hash of all files within it
-	if [[ -d $CACHE_PATH ]]; then
-		CACHE_KEY=$(hash_directory "$CACHE_PATH")
-		echo "	'$CACHE_PATH' is a directory with the hash $CACHE_KEY"
-
-	# if the $CACHE_PATH is a regular file, derive the key from the file's hash
-	elif [[ -f $CACHE_PATH ]]; then
-		CACHE_KEY=$(hash_file "$CACHE_PATH")
-		echo "	'$CACHE_PATH' is a file with the hash $CACHE_KEY"
-	fi
+if [ -z "${2:-}" ]; then
+  echo "You must pass the key to use to identify the cache."
+  exit 1
+else
+  CACHE_KEY=$1
 fi
 
 S3_BUCKET_NAME=${CACHE_BUCKET_NAME-}

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -5,6 +5,7 @@ if [ -z "${1:-}" ]; then
   exit 1
 else
   CACHE_PATH=$1
+  shift
 fi
 
 if [ ! -f "$CACHE_PATH" ] && [ ! -d "$CACHE_FILE" ]; then
@@ -12,12 +13,50 @@ if [ ! -f "$CACHE_PATH" ] && [ ! -d "$CACHE_FILE" ]; then
   exit 1
 fi
 
-if [ -z "${2:-}" ]; then
+if [ -z "${1:-}" ]; then
   echo "You must pass the key to use to identify the cache."
   exit 1
 else
   CACHE_KEY=$1
+  shift
 fi
+
+# Defaults options, will be overridden by getopts if necessary.
+SHOULD_FORCE=false
+SHOULD_USE_RELATIVE_PATH_IN_TAR=false
+
+while getopts ":fr-" opt; do
+  case "${opt}" in
+    f)
+      SHOULD_FORCE=true
+      ;;
+    r)
+      SHOULD_USE_RELATIVE_PATH_IN_TAR=true
+      ;;
+    -)
+      case "${OPTARG}" in
+        force)
+          SHOULD_FORCE=true
+          ;;
+        use_relative_path_in_tar)
+          SHOULD_USE_RELATIVE_PATH_IN_TAR=true
+          ;;
+        *)
+          echo "Invalid option: --${OPTARG}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
 
 S3_BUCKET_NAME=${CACHE_BUCKET_NAME-}
 if [ -z "$S3_BUCKET_NAME" ]; then
@@ -33,8 +72,7 @@ fi
 echo "Using $S3_BUCKET_NAME as cache bucket"
 
 # Use with caution – in general it's not a good idea to overwrite a cache entry
-SHOULD_FORCE=${3-false}
-if [[ "$SHOULD_FORCE" == '--force' ]]; then
+if [[ "$SHOULD_FORCE" == true ]]; then
 	echo "Deleting the existing cache key"
 	aws s3 rm "s3://$S3_BUCKET_NAME/$CACHE_KEY"
 fi
@@ -43,8 +81,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	echo "No existing cache entry for $CACHE_KEY – storing in cache"
 
 	echo "	Compressing"
-	TAR_CONFIG=${4-}
-	if [[ "$TAR_CONFIG" == '--use_relative_path_in_tar' ]]; then
+	if [[ "$SHOULD_USE_RELATIVE_PATH_IN_TAR" == true ]]; then
 		# This is used by actions such as `install_swiftpm_dependencies`
 		# This configuration allows the tar to not include the full system path of the
 		# directory that's being archived. For example, this will save only the

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -56,7 +56,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 		# directory that's being archived. For example, this will save only the
 		# "DIRECTORY_BEING_ARCHIVED" in `/User/builder/DIRECTORY_BEING_ARCHIVED`
 		# instead of also creating `/User/builder` when extracting the archive
-		tar -czf "$CACHE_KEY" -C "$CACHE_FILE" .
+		tar -czf "$CACHE_KEY" --directory "$CACHE_FILE" .
 	else
 		tar -czf "$CACHE_KEY" "$CACHE_FILE"
 	fi

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,24 +1,24 @@
 #!/bin/bash -eu
 
 if [ -z "${1:-}" ]; then
-  echo "You must pass the file or directory you want to be cached"
-  exit 1
+	echo "You must pass the file or directory you want to be cached"
+	exit 1
 else
-  CACHE_PATH=$1
-  shift
+	CACHE_PATH=$1
+	shift
 fi
 
 if [ ! -f "$CACHE_PATH" ] && [ ! -d "$CACHE_FILE" ]; then
-  echo "$CACHE_PATH should be either a file nor a directory"
-  exit 1
+	echo "$CACHE_PATH should be either a file nor a directory"
+	exit 1
 fi
 
 if [ -z "${1:-}" ]; then
-  echo "You must pass the key to use to identify the cache."
-  exit 1
+	echo "You must pass the key to use to identify the cache."
+	exit 1
 else
-  CACHE_KEY=$1
-  shift
+	CACHE_KEY=$1
+	shift
 fi
 
 # Defaults options, will be overridden by getopts if necessary.
@@ -26,36 +26,36 @@ SHOULD_FORCE=false
 SHOULD_USE_RELATIVE_PATH_IN_TAR=false
 
 while getopts ":fr-" opt; do
-  case "${opt}" in
-    f)
-      SHOULD_FORCE=true
-      ;;
-    r)
-      SHOULD_USE_RELATIVE_PATH_IN_TAR=true
-      ;;
-    -)
-      case "${OPTARG}" in
-        force)
-          SHOULD_FORCE=true
-          ;;
-        use_relative_path_in_tar)
-          SHOULD_USE_RELATIVE_PATH_IN_TAR=true
-          ;;
-        *)
-          echo "Invalid option: --${OPTARG}" >&2
-          exit 1
-          ;;
-      esac
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
-      ;;
-    :)
-      echo "Option -$OPTARG requires an argument." >&2
-      exit 1
-      ;;
-  esac
+	case "${opt}" in
+		f)
+			SHOULD_FORCE=true
+			;;
+		r)
+			SHOULD_USE_RELATIVE_PATH_IN_TAR=true
+			;;
+		-)
+			case "${OPTARG}" in
+				force)
+					SHOULD_FORCE=true
+					;;
+				use_relative_path_in_tar)
+					SHOULD_USE_RELATIVE_PATH_IN_TAR=true
+					;;
+				*)
+					echo "Invalid option: --${OPTARG}" >&2
+					exit 1
+					;;
+			esac
+			;;
+		\?)
+			echo "Invalid option: -$OPTARG" >&2
+			exit 1
+			;;
+		:)
+			echo "Option -$OPTARG requires an argument." >&2
+			exit 1
+			;;
+	esac
 done
 
 S3_BUCKET_NAME=${CACHE_BUCKET_NAME-}


### PR DESCRIPTION
Following up on [this suggestion](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/43/files#r1125786294) before looking into using the command for the Gutenberg work I'm doing at the moment.

~~⚠️ _Apologies for the tab vs spaces changes. I'll try to fix them before merging._~~

## WIP / RFC

I removed the `CACHE_KEY` computation logic if the parameter was not passed because it was never used. What do you think? I don't think this change would require a major version bump because: 

> We can say with confidence that it never run because 1) all the callers in this plugin pass a cache and 2) because of the `u` flag in the shebang, the line `CACHE_KEY=$2` would have failed the script if no value had been passed, therefore never running the fallback logic. Moreover, the script uses `$3` and `$4` later on, further proving that `$2` was always, implicitly, required.

So, while technically making `$2` required when it previously wasn't should count as a breaking change, in practice `$2` was always required and I think we shouldn't worry with that.

_However_... Since we are taking the time to add options it might be beneficial to use them for both the path to archive and the key to use. That's would make the command more robust, as it would be order agnostic. `save_cache --path PATH_TO_CACHE --key KEY` works just as well as `save_cache --key KEY --path PATH_TO_CACHE` but `save_cache PATH_TO_CACHE KEY` and `save_cache KEY PATH_TO_CACHE` produce different results. If we were to do that, then it would definitely count as a breaking change.

What do you think?

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
