### PR TITLE
Fail `bin/upload_artifact` with a message if `$1` is unbound

### DIFF
--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -6,11 +6,11 @@
 # $file_path is the path to a file on disk. It'll automatically be combined with the current build ID to differentiate between
 # the same file in different jobs so that it can be correctly re-downloaded within the same job.
 
-ARTIFACT_PATH=$1
-
-if [ -z "$ARTIFACT_PATH" ]; then
+if [ -z "${1-}" ]; then
 	echo "You must pass the file you want to be stored"
 	exit 1
+else
+	ARTIFACT_PATH=$1
 fi
 
 if [ ! -f "$ARTIFACT_PATH" ]; then

--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -37,4 +37,3 @@ if [ "$ACCELERATION_STATUS" = "Enabled" ]; then
 else
 	aws s3 cp "$ARTIFACT_PATH" "s3://$BUCKET/$KEY"
 fi
-

--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # Usage
-# store_artifact $file_path
+# upload_artifact $file_path
 #
 # $file_path is the path to a file on disk. It'll automatically be combined with the current build ID to differentiate between
 # the same file in different jobs so that it can be correctly re-downloaded within the same job.


### PR DESCRIPTION
Before:

<img width="1027" alt="image" src="https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/1218433/131eecbc-e6e9-4439-bfde-5d0733897776">

After:

<img width="1057" alt="image" src="https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/1218433/9094e798-e42e-4374-8c11-3f36a33aa7ec">

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
