### PR TITLE
Prepare for release 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 2.16.0
+
+### New Features
+
 - Add a new `github_api` utlity to make API requests to GitHub.com or Github Enterprise instances. [#51]
 - Extend the `comment_on_pr` utility to update or delete the existing comment. [#51]
 


### PR DESCRIPTION
This PR updates the change log file to prepare for v2.16.0 release, which I'll create after this PR is merged.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
