### PR TITLE
[annotate_test_failures] Include test cases with error nodes in the failures list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix the `annotate_test_failures` to include test cases with error nodes in the failures list. [#58]
 
 ### Internal Changes
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -28,6 +28,9 @@ end
 # <testcase classname='WordPressTest.MediaServiceTests' name='testDeletingLocalMediaThatDoesntExistInCoreData'>
 #   <failure message='Asynchronous wait failed: Exceeded timeout of 0.1 seconds, with unfulfilled expectations: &quot;The delete call succeeds even if the media object isn&apos;t saved.&quot;.'>&lt;unknown&gt;:0</failure>
 # </testcase>
+# <testcase classname="tests.test_editing_drafts.TestEditingDrafts" name="test_adding_a_photo_to_text_draft">
+#   <error message="failed on setup with &quot;TypeError: list indices must be integers or slices, not str&quot;">Traceback (most recent call last): ...</error>
+# </testcase>
 # <testcase classname='WordPressTest.MediaServiceTests' name='testDeletingLocalMediaThatDoesntExistInCoreData' time='0.145'/>
 #
 class TestFailure
@@ -37,7 +40,7 @@ class TestFailure
   def initialize(node)
     @classname = node['classname']
     @name = node['name']
-    failure_node = node.elements['failure']
+    failure_node = node.elements['failure'] || node.elements['error']
     @message = failure_node['message']
     @details = failure_node.text
     @count = 1
@@ -62,7 +65,7 @@ class TestFailure
 
   def ultimately_succeeds?(parent_node:)
     all_same_test_nodes = parent_node.get_elements("testcase[@classname='#{@classname}' and @name='#{@name}']")
-    !all_same_test_nodes.last.elements['failure'] # If last node found for that test doesn't have a <failure> child, then test ultimately succeeded.
+    !(all_same_test_nodes.last.elements['failure'] || all_same_test_nodes.last.elements['error']) # If last node found for that test doesn't have a <failure> or <error> child, then test ultimately succeeded.
   end
 
   def ==(other)
@@ -106,7 +109,7 @@ xmldoc = REXML::Document.new(file)
 
 failures = []
 flakies = []
-REXML::XPath.each(xmldoc, '//testcase[failure]') do |node|
+REXML::XPath.each(xmldoc, '//testcase[failure|error]') do |node|
   test_failure = TestFailure.new(node)
 
   if test_failure.ultimately_succeeds?(parent_node: node.parent)


### PR DESCRIPTION
## Description

`annotate_test_failures` doesn't recognize as failures the tests that have an `error` node instead of a `failure` one.
`Pytest` for example reports failures in fixtures as errors, not as failures.

More context: p1684494232589389-slack-C02K7C5K8TD

## How to test

Tested locally with a this input:

```
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
  <testsuite name="pytest" errors="2" failures="2" skipped="1" tests="6">
    <testcase classname="some.class" name="test_passed">
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="some.class" name="test_with_error">
      <error message="failed on setup with &quot;TypeError: list indices must be integers or slices, not str&quot;">
        Traceback (most recent call last):...
      </error>
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="come.class" name="test_with_failure">
      <failure message="selenium.common.exceptions.TimeoutException: Message: &#10;Stacktrace:&#10;NoSuchElementError">
        Traceback (most recent call last):
      </failure>
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="some.class" name="test_skipped">
      <skipped type="pytest.skip" message="skipped test">some skip details</skipped>
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="some.class" name="test_flaky_with_error">
      <error message="failed on setup with &quot;TypeError: list indices must be integers or slices, not str&quot;">
        Traceback (most recent call last):...
      </error>
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="some.class" name="test_flaky_with_error">
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="come.class" name="test_flaky_with_failure">
      <failure message="selenium.common.exceptions.TimeoutException: Message: &#10;Stacktrace:&#10;NoSuchElementError">
        Traceback (most recent call last):
      </failure>
      <system-err>Captured Err</system-err>
    </testcase>
    <testcase classname="come.class" name="test_flaky_with_failure">
      <system-err>Captured Err</system-err>
    </testcase>
  </testsuite>
</testsuites>
```

The result was as expected, 2 failures and 2 flaky tests, with console output:

```
2 test(s) have failed (2 distinct assertion failures in total). Reporting them as a `Tests (have failed)` Buildkite error annotation.

#### Tests: 2 tests have failed (2 distinct assertion failure(s) in total)

<details><summary><tt>test_with_error</tt> in <tt>some.class</tt></summary>
failed on setup with "TypeError: list indices must be integers or slices, not str"
        Traceback (most recent call last):...
</details>

<details><summary><tt>test_with_failure</tt> in <tt>come.class</tt></summary>
selenium.common.exceptions.TimeoutException: Message: 
Stacktrace:
NoSuchElementError
        Traceback (most recent call last):
</details>
2 test(s) were flaky (2 distinct assertion failures in total). Reporting them as a `Tests (were flaky)` Buildkite warning annotation.

#### Tests: 2 tests were flaky (2 distinct assertion failure(s) in total)

<details><summary><tt>test_flaky_with_error</tt> in <tt>some.class</tt></summary>
failed on setup with "TypeError: list indices must be integers or slices, not str"
        Traceback (most recent call last):...
</details>

<details><summary><tt>test_flaky_with_failure</tt> in <tt>come.class</tt></summary>
selenium.common.exceptions.TimeoutException: Message: 
Stacktrace:
NoSuchElementError
        Traceback (most recent call last):
</details>

```

##

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
