### PR TITLE
Add `git diff` to `Podfile.lock` diverged annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ _None._
 
 ### Bug Fixes
 
-- Fix the `annotate_test_failures` to include test cases with error nodes in the failures list. [#58]
+_None._
 
 ### Internal Changes
 
@@ -38,11 +38,11 @@ _None._
 
 ### New Features
 
-_None._
+- When `install_cocoapods` fails because `Podfile.lock` changed in CI, it now prints a diff of the changes [#59]
 
 ### Bug Fixes
 
-_None._
+- Fix the `annotate_test_failures` to include test cases with error nodes in the failures list. [#58]
 
 ### Internal Changes
 

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -32,8 +32,20 @@ else
 fi
 
 function lockfile_error () {
-  message="\`Podfile.lock\` was changed by \`bundle exec pod install\`. Please run \`bundle exec pod install\` locally with a clean cache and commit the result."
+  message=$(cat <<EOF
+  \`Podfile.lock\` was changed by \`bundle exec pod install\`. Please run \`bundle exec pod install\` locally with a clean cache and commit the result.
+
+  <details><summary>See diff</summary>
+
+  \`\`\`
+  $(git diff -- Podfile.lock)
+  \`\`\`
+  </details>
+EOF
+  )
+
   echo "$message"
+
   buildkite-agent annotate "$message" --style 'error' --context 'ctx-error'
 }
 trap lockfile_error ERR


### PR DESCRIPTION
I was baffled today by a test build failing because the `Podfile.lock` changed in CI even though running `bundle exec pod install` locally didn't make it change for me.

I found it useful to print the diff that triggered the failure, which revealed the code I wrote was printing absolute paths in the `Podfile.lock`.

[In action](https://buildkite.com/automattic/wordpress-ios/builds/14343#0188516d-6cf8-4f71-b295-9e0cfe440414):
 
![image](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/1218433/7ca670f4-f121-410b-8a27-de2560fe65e8)

![image](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/1218433/39599424-5ca1-4583-be1c-e4edb5b7b99a)

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
