### PR TITLE
Add `diff` language specification to `Podfile.lock` diff annotation

### DIFF
--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -37,7 +37,7 @@ function lockfile_error () {
 
   <details><summary>See diff</summary>
 
-  \`\`\`
+  \`\`\`diff
   $(git diff -- Podfile.lock)
   \`\`\`
   </details>


### PR DESCRIPTION
In #59, @AliSoftware suggested adding `diff` to the code block in the `Podfile.lock` diverged failure annotation, to see if Buildkite also adds syntax highlighting to the rendered Markdown.

I implemented it here and made a test PR [on Woo iOS](https://github.com/woocommerce/woocommerce-ios/pull/9832). It doesn't look like there's any syntax highlighting in the annotation 😞 

![image](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/1218433/6b3b6b2a-e9db-4cc8-b714-6c05b7c8594d)

On the other hand, the `diff` in the code block is not rendered in the code, which makes me hopeful. Or, at least, it makes it look like an harmless change to add.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
