### PR TITLE
`annotate_test_failures`: Fix case of special characters in step label / annotation context

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,10 +7,3 @@ steps:
 
   - label: ":docker: Test"
     command: make test
-
-  - label: "Test Annotations"
-    commands:
-      - buildkite-agent annotate "Regular Context" --context "regular-context"
-      - buildkite-agent annotate "Tricky Context" --context "regular context \#2"
-      - buildkite-agent annotation remove --context "regular-context" || true
-      - buildkite-agent annotation remove --context "regular context \#2" || true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,3 +7,10 @@ steps:
 
   - label: ":docker: Test"
     command: make test
+
+  - label: "Test Annotations"
+    commands:
+      - buildkite-agent annotate "Regular Context" --context "regular-context"
+      - buildkite-agent annotate "Tricky Context" --context "regular context \#2"
+      - buildkite-agent annotation remove --context "regular-context" || true
+      - buildkite-agent annotation remove --context "regular context \#2" || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _None._
 ### Bug Fixes
 
 - `annotate_test_failures` no longer prints an empty `<code>` box when reporting a `failure` with no extra `details`. [#63]
+- `annotate_test_failures` is now able to remove annotations on successful step retry _even if_ the step label contains special characters. [#65]
 
 ### Internal Changes
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -118,7 +118,8 @@ end
 # Given a list of failures for a given step and state, update the corresponding annotation
 #
 def update_annotation(title, list, style, state)
-  annotation_context = "#{title} (#{state})"
+  step_id = ENV.fetch('BUILDKITE_STEP_ID', title)
+  annotation_context = "step-#{step_id}-#{state}".downcase.gsub(/\W/, '-')
   if list.empty?
     puts "No test #{state}. Removing any previous `#{annotation_context}` Buildkite annotation if any.\n\n"
     system("buildkite-agent annotation remove --context #{annotation_context.shellescape} 2>/dev/null || true")


### PR DESCRIPTION
# Why?

This fixes an issue with the `annotate_test_failures` utility when the `BUILDKITE_LABEL` happens to contains special characters, like is the case for example in Tumblr-Android with steps named `E2E tests #1` and `E2E tests #2`.

Those `#` in the label means that the string we derive from it to use as the annotation context end up messing things up, because that `#` is not escaped, and [when we try to `buildkite-agent annotation remove --context 'E2E tests #1'`, this fails to find the annotation and to remove it](https://buildkite.com/automattic/tumblr-android/builds/17405), because of that special character confusing the Buildkite agent API(†).

(†) That hypothesis (about why those "E2E tests #1" / "E2E tests #2" annotations were never removed on step retry in Tumblr because of that `#` character messing things up) was confirmed via [this commit](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/65/commits/2b504cdef1eca145db0b9f6ed023f07498a5dd74) and [this CI build](https://buildkite.com/automattic/ci-toolkit-buildkite-plugin/builds/495#018901ab-9850-4fc1-a672-81387a9bac58/118-123), by creating two annotations, one with a regular context string and one with a tricky one, and showing that the regular one was removed as expected but the tricky one failed to be removed due to its `#` character in the context string.

# How?

 - Use the `BUILDKITE_STEP_ID` instead of `BUILDKITE_LABEL` to construct the annotation context string. That env var not only is an UUID and thus guaranteed to not have any special characters, but also keeps the same value across multiple retries of the same step (as opposed to `BUILDKITE_JOB_ID` which is a new UUID on every retry)
 - Use `.downcase.gsub(/\W/, '-')` to "slug-ify" the context string, ensuring any character other than `[a-z0-9_]` are turned into a `-`. This is still needed despite `BUILDKITE_STEP_ID` being a UUID without special characters, because the string we build to use for the annotation context must also include the value of `state` variable (`"have failed"` / `"were flaky"`) to allow one step to generate multiple annotations for reporting different states and types of test failures/warnings.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

cc @adimoldovan FYI as to why the Buildkite annotations were never removed like they were expected to after a successful retry of the "E2E tests #N" steps on Tumblr-Android.