### PR TITLE
Fix `annotate_test_failures` for steps using `parallelism`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,13 @@ _None._
 
 _None._
 
+## 2.18.1
+
+### Bug Fixes
+
+- `annotate_test_failures` no longer prints an empty `<code>` box when reporting a `failure` with no extra `details`. [#63]
+- Fix an issue with `annotate_test_failures` on CI steps that are using the `parallelism` attribute. [#67]
+
 ## 2.18.0
 
 ### Bug Fixes

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -118,8 +118,8 @@ end
 # Given a list of failures for a given step and state, update the corresponding annotation
 #
 def update_annotation(title, list, style, state)
-  step_id = ENV.fetch('BUILDKITE_STEP_ID', title)
-  annotation_context = "step-#{step_id}-#{state}".downcase.gsub(/\W/, '-')
+  ctx_components = ['test-summary', ENV.fetch('BUILDKITE_STEP_ID', title), ENV.fetch('BUILDKITE_PARALLEL_JOB', nil), state]
+  annotation_context = ctx_components.compact.join('-').downcase.gsub(/\W/, '-')
   if list.empty?
     puts "No test #{state}. Removing any previous `#{annotation_context}` Buildkite annotation if any.\n\n"
     system("buildkite-agent annotation remove --context #{annotation_context.shellescape} 2>/dev/null || true")


### PR DESCRIPTION
## Why

This addresses the issue that [we noticed in Tumblr-Android after adopting `2.18.0`](https://github.tumblr.net/TumblrMobile/android2/pull/20660#issuecomment-624108), where if we have a `step` that uses `parallelism` attribute to create multiple parallel jobs from a single step, those jobs will all use the same `BUILDKITE_STEP_ID`.

This is a problem because we want to allow the different jobs to use different annotation contexts, to be able to add/remove their own annotations without risking conflicting with the annotations from the other parallel job instances of that same step, otherwise one job from that step would override the annotation from the other.

## How

The solution is to also include the value of `BUILDKITE_PARALLEL_JOB` env var, if it's defined, in the annotation context string.

## Testing

[I've created a test commit on Tumblr-Android to point to this branch of the `a8c-ci-toolkit` with the fix, and to fake the failures (by making the `run-e2e-tests.sh` script copy a JUnit report with failures if `BUILDKITE_RETRY_COUNT=0`, and one with success otherwise)](https://github.tumblr.net/TumblrMobile/android2/commit/dfffa2ea7aae26ebfae70f39687e2a1a06067332).

1️⃣  After the first run of [the Build](https://buildkite.com/automattic/tumblr-android/builds/17496), the CI page looked like this, proving that two different jobs created by the same step (`E2E test #N`) now can create separate annotations
<img width="1164" alt="image" src="https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/216089/7c399cd1-0137-4b41-b35f-160c76b23c6d">

2️⃣  After hitting "Retry" on each of the fake-failed steps, all 3 annotations have disappeared (I've effectively seen them disappear one at at time as I retried the steps one at a time)
<img width="1163" alt="image" src="https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/assets/216089/6b8f7957-b11c-48b1-b27b-75148a8f2724">
