### PR TITLE
Add `pnginfo` utility to check PNG files

### DIFF
--- a/bin/pnginfo
+++ b/bin/pnginfo
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require 'json'
+
+PNG_MAGIC_NUMBER = '89504e470d0a1a0a'
+COLOR_TYPES = { 0 => 'Greyscale', 2 => 'Truecolor', 3 => 'Indexed-color', 4 => 'Greyscale with alpha', 6 => 'Truecolor with alpha' }.freeze
+
+ImageFormat = Struct.new(:width, :height, :depth, :color_type, :has_alpha)
+
+####################
+# Helper Functions
+####################
+
+# Parse a binary PNG file to find IHDR chunk with format info (and tRNS chunk if it exists)
+# @param [String] input_file The path to the PNG file we want to parse
+# @return [ImageFormat] Image format information, or nil if not a valid PNG file
+# @see https://www.w3.org/TR/png/#5DataRep
+def parse_png_file(input_file)
+  File.open(input_file, 'rb') do |f|
+    magic = f.read(8).unpack1('H*')
+    if magic != PNG_MAGIC_NUMBER
+      puts "🔴 #{input_file} is not a PNG file."
+      return nil
+    end
+
+    width, height, depth, color_type = [nil, nil, nil, nil]
+    has_trns = false
+
+    # https://www.w3.org/TR/png/#5Chunk-layout
+    loop do
+      break if f.eof?
+
+      chunk_length = f.read(4).unpack1('L>')
+      chunk_type = f.read(4)
+
+      if chunk_type == 'IHDR'
+        # Read IHDR chunk — https://www.w3.org/TR/png/#11IHDR
+        width, height, depth, color_type = f.read(chunk_length).unpack('L>L>CC')
+      else
+        has_trns = true if chunk_type == 'tRNS' # https://www.w3.org/TR/png/#11tRNS
+        # Skip chunk data we don't care about, and advance to next chunk
+        f.seek(chunk_length + 4, IO::SEEK_CUR) # CRC is 4 extra bytes after chunk data
+      end
+    end
+
+    # See https://www.w3.org/TR/png/#3colourType and https://www.w3.org/TR/png/#6AlphaRepresentation
+    return ImageFormat.new(width, height, depth, color_type, has_trns || (color_type & 0x4 != 0))
+  end
+end
+
+####################
+# Parse Command Line Arguments
+####################
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = 'Usage: pnginfo [options]'
+
+  opts.on('--json', '-j', 'Print all format info as JSON') { options[:json] = true }
+  opts.on('--width[=value]', '-w', Integer, 'Prints or check image width') { |v| options[:width] = v }
+  opts.on('--height[=value]', '-h', Integer, 'Prints or check image height') { |v| options[:height] = v }
+  opts.on('--size[=wxh]', '-s', String, 'Prints or check image size, as {width}x{height}') { |v| options[:size] = v }
+  opts.on('--depth[=value]', '-d', Integer, 'Prints or check bit depth (aka bits per sample)') { |v| options[:depth] = v }
+  opts.on('--color', '-c', 'Prints color type') { options[:color_type] = nil }
+  opts.on('--alpha[=true|false]', '-a', 'Prints or check if image has alpha channel') { |v| options[:has_alpha] = v.nil? ? nil : %w[1 true yes].include?(v) }
+
+  opts.on('--help', '-h') do
+    puts opts
+    exit
+  end
+end.parse!
+
+all_props = %i[width height size depth color_type has_alpha]
+all_props.each { |k| options[k] = nil } if all_props.none? { |k| options.key?(k) }
+
+if ARGV.length != 1
+  puts "Error: Expected 1 argument (input file), got #{ARGV.length}."
+  exit 2
+end
+file = ARGV.first
+
+####################
+# Main
+####################
+
+fmt = parse_png_file(file)
+exit 3 if fmt.nil?
+
+h = {}
+exit_code = 0
+
+check_prop = proc do |key, &block|
+  if options.key?(key)
+    h[key] = block.call
+    if !options[key].nil? && h[key] != options[key]
+      warn "\e[31mError: #{key} does not match expected value of #{options[key]}\e[m"
+      exit_code = 1
+    end
+  end
+end
+
+check_prop.call(:width) { fmt.width }
+check_prop.call(:height) { fmt.height }
+check_prop.call(:size) { "#{fmt.width}x#{fmt.height}" }
+check_prop.call(:depth) { fmt.depth }
+check_prop.call(:color_type) { COLOR_TYPES[fmt.color_type] }
+check_prop.call(:has_alpha) { fmt.has_alpha }
+
+if options[:json]
+  puts h.to_json
+else
+  h.each { |k, v| puts " - #{k}: #{v}" }
+end
+
+exit(exit_code)


### PR DESCRIPTION
## Why?

This utility will be mostly useful to check if a PNG file is of expected size and if it has an alpha channel or not.

The most typical use case for this is to have a CI check validate that iOS App Icons are 1024x1024 and don't have an alpha channel (otherwise they'd be rejected from review), or to validate the size of App Store screenshots.

In the past we've used Mac agents to do this kind of App Icon check, leveraging `sips -g hasAlpa` to check PNG files. But `sips` is only available on macOS, hence the Mac agent requirement to run that.

Given the only thing we need is to check the PNG file format, we shouldn't need to have to use a Mac to run such checks. 
This is why I've implemented this simple ruby tool, that can be used in any Linux agent where ruby is installed, allowing those CI steps for those PNG checks not only to likely run faster (as Linux VMs are faster to bootstrap) but most importantly to avoid those CI steps to request a Mac agent (which we don't have in huge numbers in our CI fleet) and thus reduce the stress on our Mac CI queue.

## How?

After a quick check with [the official PNG specification](https://www.w3.org/TR/png/#5DataRep), the format ends up not being super complicated to parse, especially since all we're interested in is the content of the `IHDR` (Image Header) chunk—which is fairly simple—and to check for the _presence_ of a `tRNS` chunk (which indicates that there is some tRaNSparency data)

### PNG data parsing

The implementation for parsing the PNG file goes like this:

 - Opens the PNG file (in binary mode)
 - Verify the magic number signature at the beginning of the file to validate it's a PNG file
 - Go thru all the data chunks (whose structure is always `[LENGTH] [TYPE] [DATA] [CRC]`, see https://www.w3.org/TR/png/#5Chunk-layout), and for each:
    - If the chunk type is `IHDR`, then read the width, height, bit depth and color mode out of that chunk data
    - If the chunk type is `tRNS`, then take note that such a chunk exists in the stream (we don't care about its data, just that such a chunk is present)
    - Otherwise just `seek` / skip to the next chunk, up to the end of file

The rest of the script is just fancy `OptionParser` and command-line handling stuff.

### Command options

The `pnginfo` script is designed to be used:
 - Either to just print info about the image format. For example:
    - `pnginfo <file>` will print all the format information
    - `pnginfo --alpha --size <file>` will only print requested format information fields, here printing if the image has an alpha channel and it's size (width x height)
    - The `--json` option also allows for the information to be output in JSON format (e.g. for use with `jq`) instead of plain text
 - Or to check that a certain format field has some expected value. For example:
    - `pnginfo --alpha=false <file>` will not only print if the image has an alpha channel or not, but will also print an error and `exit 1` if it does have an alpha channel (while we expected it to be `false`), or `exit 0` if `alpha` is `false` as expected.
    - `pnginfo --width=768 --height=1024 <file>`, or its shorter form `pnginfo --size=768 <file>`, will check that the file is exactly 768x1024 pixels in size. For example, this could be useful to test if PNG files used for AppStore or PlayStore screenshots are the expected size.
    - `pnginfo --alpha=false --size=1024x1024 Icon.png` would for example be a typical example of this command to check that an iOS App Icon is not only of the expected size, but also ensure that it doesn't have an alpha channel, since that would be cause for TestFlight rejection.

### Testing

 - I've tested various calls of this script/tool locally with a couple of PNG files and it worked as expected
 - This new utility will be tested in Tumblr-iOS, as part of https://github.tumblr.net/TumblrMobile/orangina/pull/25483 and the CI step to Validate App Icons.