### PR TITLE
Fix `install_gems`'s `CACHE_KEY` when using `RBENV_VERSION`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ _None._
 ### Bug Fixes
 
 - Ensure that `install_gems` doesn't restore a macOS cache on Linux build machines. [#69]
+- Ensute that `install_gems` uses the correct ruby version in its `CACHE_KEY` in all cases [#70]
 
 ### Internal Changes
 

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -2,7 +2,7 @@
 
 PLATFORM=$(uname -s)
 ARCHITECTURE=$(uname -m)
-RUBY_VERSION=$(cat .ruby-version)
+RUBY_VERSION=$(rbenv version-name 2>/dev/null || cat .ruby-version)
 GEMFILE_HASH=$(hash_file Gemfile.lock)
 CACHEKEY="$BUILDKITE_PIPELINE_SLUG-$PLATFORM-$ARCHITECTURE-ruby$RUBY_VERSION-$GEMFILE_HASH"
 


### PR DESCRIPTION
## Why

When the ruby version is forced by a mean _other_ than the local `.ruby-version` file—especially when it is set via `export RBENV_VERSION` instead—then the `RUBY_VERSION` variable that is used to build the `CACHE_KEY` picks up the wrong ruby version value.

This is in particular the case [in the `release-toolkit` pipeline](https://github.com/wordpress-mobile/release-toolkit/blob/trunk/.buildkite/pipeline.yml#L30), which uses `export RBENV_VERSION={{ matrix.ruby }}` to test our codebase against multiple ruby versions as part of a build matrix. In such cases, the `.ruby-version` file is unchanged and still contains `2.7.4` (as the ruby version we expect developers to use locally when they work on the `release-toolkit`), but the CI step dynamically change it via the env var instead.

## How

Make `RUBY_VERSION` use `rbenv version-name` to determine the ruby version instead. We still fallback to `cat .ruby-version` as a precaution, in case `rbenv` were not installed on the machine running that code.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
