### PR TITLE
Refine message in `annotate_test_failures` when optional config missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Refine message in `annotate_test_failures` when configuration for optional Slack reporting is missing [#74]
 
 ## 2.18.2
 

--- a/bin/annotate_test_failures
+++ b/bin/annotate_test_failures
@@ -211,8 +211,12 @@ end
 update_annotation(title, failures, 'error', 'have failed')
 update_annotation(title, flakies, 'warning', 'were flaky')
 
-if slack_channel.nil? || slack_webhook.nil?
-  puts '⏩ No `--slack` channel name and/or `--slack-webhook` URL provided; skipping Slack notification.'
+if slack_channel.nil?
+  if slack_webhook.nil?
+    puts '⏩ No `--slack` channel name nor `--slack-webhook`/`$SLACK_WEBHOOK` URL provided; skipping Slack notification.'
+  else
+    puts '⏩ No `--slack` channel name provided; skipping Slack notification.'
+  end
 else
   send_slack_notification(slack_webhook, slack_channel, title, failures) unless failures.empty?
 end


### PR DESCRIPTION
I configured Slack reporting in https://github.com/wordpress-mobile/gutenberg-mobile/pull/6134 based on what I saw in WordPress iOS and was surprised by the info message I got. _Why did that string work in WP but not on my project_? I turns out that WP set the webhook via an env var. Admittedly, It didn't take long to find that out by looking at the code. Still, I decided to update the "Slack skipped" message to something I think would have been clearer for me at the time.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
