### PR TITLE
install_swiftpm_dependencies: prevent Package.resolved from being updated

### DIFF
--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -40,7 +40,7 @@ add_host_to_ssh_known_hosts github.com
 # Based on the project type, resolve the packages using the correct build type
 if [[ "$BUILD_TYPE" == "XCODEBUILD" ]]; then
   echo "	Resolving packages with \`xcodebuild\`"
-  xcodebuild -resolvePackageDependencies
+  xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
 elif [[ "$BUILD_TYPE" == "SWIFT" ]]; then
   echo "	Resolving packages with \`swift\`"
   swift package resolve


### PR DESCRIPTION
## Why?

This came up in a Slack discussion (p1696008080699129/1696006524.465569-slack-C02KLTL3MKM) and also [in the Swift forums](https://forums.swift.org/t/xcode-ignoring-package-resolved-file/65031/6).

When calling `xcodebuild -resolvePackageDependencies`, Xcode might happily update the `Package.resolved` file instead of treating it like a lockfile (like other dependency managers do).

Basically, to my understanding, `xcodebuild -resolvePackageDependencies` is akin to `pod update`, in the sense that it might not just resolve the dependencies but also update them… while if you only want the equivalent of `pod install` aka install exactly what's in the `Package.resolved` without trying to _update_ any dependency, you have to add this `-onlyUsePackageVersionsFromResolvedFile` flag explicitly?

This has caused issue in our CI builds on Tumblr-iOS after recently introducing a call to `install_swiftpm_dependencies` in our pipeline, because some of our lanes also check `ensure_git_repo_clean` and they were thus failing due to that utility causing a change on the `Package.resolved` file.

## Testing

I believe, based on what I've been reading in the Swift forums and my understanding of the problem, that this change would fix that issue and prevent `Package.resolved` from being updated when we don't want to, but haven't actually tested it.

Just making that PR so we don't forget about it, but we should probably first test it by pointing Tumblr-iOS's `a8c-ci-toolkit` plugin to the branch of this PR, then restore our calls to `ensure_git_repo_clean` in our CI lanes, and check if that it indeed prevents the `Package.resolved` from being changed and failing the check.


---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
