### PR TITLE
Add a hack to patch cocoapods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Fix an issue where `validate_podspec` and `publish_pod` fail on Xcode 15.0.1 if the pod has a dependency which targets iOS version older than 13. [#78]
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## 3.0.1
+
+### Internal Changes
+
 - Fix an issue where `validate_podspec` and `publish_pod` fail on Xcode 15.0.1 if the pod has a dependency which targets iOS version older than 13. [#78]
 
 ## 3.0.0

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#2.18.2:
+      - automattic/a8c-ci-toolkit#3.0.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `2.18.2`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.0.0`.
 
 ## Configuration
 

--- a/bin/patch-cocoapods
+++ b/bin/patch-cocoapods
@@ -44,4 +44,4 @@ fi
 
 echo "Failed to patch cocoapods. Try to re-apply the patch"
 echo "$patch_content" | patch --reverse --force --directory "$cocoapods_gem_path" --strip 0
-echo "$patch_content" | patch --forward --force --directory "$cocoapods_gem_path" --strip 0;
+echo "$patch_content" | patch --forward --force --directory "$cocoapods_gem_path" --strip 0

--- a/bin/patch-cocoapods
+++ b/bin/patch-cocoapods
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This is a hack to workaround https://github.com/CocoaPods/CocoaPods/issues/12033.
+# We can remove this script once the issue is fixed.
+#
+# This script updates the cocoapods source code to change Xcode project targets'
+# minimal deployment target to 13.0, which is a requirement in newer Xcode versions.
+
+set -euo pipefail
+
+patch_content=$(cat <<'EOF'
+--- lib/cocoapods/installer/analyzer.rb
++++ lib/cocoapods/installer/analyzer.rb
+@@ -857,7 +857,7 @@
+           Version.new(library_spec.deployment_target(platform_name) || default)
+         end.max
+         if platform_name == :ios && build_type.framework?
+-          minimum = Version.new('8.0')
++          minimum = Version.new('13.0')
+           deployment_target = [deployment_target, minimum].max
+         end
+         Platform.new(platform_name, deployment_target)
+--- lib/cocoapods/validator.rb
++++ lib/cocoapods/validator.rb
+@@ -566,7 +566,7 @@
+     def deployment_target
+       deployment_target = spec.subspec_by_name(subspec_name).deployment_target(consumer.platform_name)
+       if consumer.platform_name == :ios && use_frameworks
+-        minimum = Version.new('8.0')
++        minimum = Version.new('13.0')
+         deployment_target = [Version.new(deployment_target), minimum].max.to_s
+       end
+       deployment_target
+EOF
+)
+
+cocoapods_gem_path=$(bundle info cocoapods --path)
+echo "Path to the cocoapods gem: $cocoapods_gem_path"
+
+if echo "$patch_content" | patch --forward --force --directory "$cocoapods_gem_path" --strip 0; then
+    echo "cocoapods patched successfully"
+    exit 0
+fi
+
+echo "Failed to patch cocoapods. Try to re-apply the patch"
+echo "$patch_content" | patch --reverse --force --directory "$cocoapods_gem_path" --strip 0
+echo "$patch_content" | patch --forward --force --directory "$cocoapods_gem_path" --strip 0;

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -1,5 +1,15 @@
 #!/bin/bash -eu
 
+PATCH_COCOAPODS="false"
+
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		*) break ;;
+	esac
+	shift
+done
+
 PODSPEC_PATH=$1
 
 # POD_NAME=$(bundle exec pod ipc spec "$PODSPEC_PATH" | jq -r '.name')
@@ -10,8 +20,11 @@ if [ -n "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then
 	exit 1
 fi
 
-echo "⚠️ Remove the patch-cocoapods step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
-patch-cocoapods
+
+if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
+	echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
+	patch-cocoapods
+fi
 
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -20,7 +20,6 @@ if [ -n "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then
 	exit 1
 fi
 
-
 if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
 	echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
 	patch-cocoapods

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -10,6 +10,9 @@ if [ -n "$BUILDKITE_TAG" ] && [ "$BUILDKITE_TAG" != "$POD_VERSION" ]; then
 	exit 1
 fi
 
+echo "⚠️ Remove the patch-cocoapods step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
+patch-cocoapods
+
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -1,5 +1,15 @@
 #!/bin/bash -eu
 
+PATCH_COCOAPODS="false"
+
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		*) break ;;
+	esac
+	shift
+done
+
 PODSPEC_PATH=$1
 PRIVATE_SPECS_REPO=$2
 DEPLOY_KEY=$3
@@ -14,6 +24,11 @@ ssh-add -l
 
 # Add the host of the spec repo (typically github.com) to the known_hosts to be sure we can clone it via ssh
 add_host_to_ssh_known_hosts "$PRIVATE_SPECS_REPO"
+
+if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
+	echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
+	patch-cocoapods
+fi
 
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -1,11 +1,23 @@
 #!/bin/bash -eu
 
+PATCH_COCOAPODS="false"
+
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		*) break ;;
+	esac
+	shift
+done
+
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :writing_hand: Patching cocoapods"
-echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
-patch-cocoapods
+if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
+	echo "--- :writing_hand: Patching cocoapods"
+	echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
+	patch-cocoapods
+fi
 
 if [ -f "Podfile.lock" ]; then
 	echo "--- :cocoapods: Setting up Pods"

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -3,6 +3,10 @@
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
+echo "--- :writing_hand: Patching cocoapods"
+echo "⚠️ Remove this step once this issue is fixed: https://github.com/CocoaPods/CocoaPods/issues/12033"
+patch-cocoapods
+
 if [ -f "Podfile.lock" ]; then
 	echo "--- :cocoapods: Setting up Pods"
 	install_cocoapods


### PR DESCRIPTION
This hack unblocks us from releasing libraries from CI. Hopefully CocoaPods can fix the issue properly and we can remove this hack soon.

This change is tested in [this build](https://buildkite.com/automattic/wordpresskit-ios/builds/1151).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
