### PR TITLE
Add `run_swiftlint` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Added `run_swiftlint` command. It will use the project's SwiftLint version defined in `.swiftlint.yml` property `swiftlint_version` to run the right SwiftLint version via Docker, reporting the warnings/errors as Buildkite annotations.
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.0.0:
+      - automattic/a8c-ci-toolkit#3.0.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.0.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.0.1`.
 
 ## Configuration
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -1,0 +1,26 @@
+#!/bin/bash -eu
+
+echo "--- :swift: Running SwiftLint"
+
+SWIFTLINT_VERSION=$(<.swiftlint.yml awk '/swiftlint_version: / {print $2}')
+SWIFTLINT_CMD="docker run --rm -v $PWD:/workspace -w /workspace ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION swiftlint"
+
+set +e
+SWIFTLINT_OUTPUT=$($SWIFTLINT_CMD lint --quiet "$@" --reporter relative-path)
+SWIFTLINT_EXIT_STATUS=$?
+set -e
+
+WARNINGS=$(echo -e "$SWIFTLINT_OUTPUT" | awk -F': ' '/: warning:/ {printf "- `%s`: %s\n", $1, $4}')
+ERRORS=$(echo -e "$SWIFTLINT_OUTPUT" | awk -F': ' '/: error:/ {printf "- `%s`: %s\n", $1, $4}')
+
+if [ -n "$WARNINGS" ]; then
+  echo "$WARNINGS"
+  printf "**SwiftLint Warnings**\n%b" "$WARNINGS" | buildkite-agent annotate --style 'warning'
+fi
+
+if [ -n "$ERRORS" ]; then
+  echo "$ERRORS"
+  printf "**SwiftLint Errors**\n%b" "$ERRORS" | buildkite-agent annotate --style 'error'
+fi
+
+exit $SWIFTLINT_EXIT_STATUS


### PR DESCRIPTION
Adding a new command to run SwiftLint on an iOS repo.
This is an iteration on the work first implemented on https://github.com/Automattic/pocket-casts-ios/pull/1326, moving the common SwiftLint script to this shared plugin.

The command will load the right SwiftLint version using the `swiftlint_version` field defined in the `.swiftlint.yml` file (props to @jkmassel for the idea), running SwiftLint via Docker and reporting warnings / errors using Buildkite annotations.

A setup testing the new command can be seen [here](https://github.com/Automattic/pocket-casts-ios/pull/1463/files#diff-a3991ebf1475eb82acab13946ffc1eca02b43917f6d5bec3898f45c8b0b9bd53L5).


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
