### PR TITLE
Support additional flags for cocoapods helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ _None._
 
 ### New Features
 
-_None._
+ - Make `validate_podspec` support `--allow-warnings`, `--sources=…`, `--private`, `--include-podspecs=…` and `--external-podspecs=…` flags that it will forward to the `pod lib lint` call. `--include-podspecs=*.podspec` is also now added by default if not provided explicitly. [#82]
+ - Make `publish_pod` support `--allow-warnings` and `--synchronous` flags that it will forward to the `pod trunk push` call. This is especially useful for repos containing multiple, co-dependant podspecs to publish at the same time, to avoid issues with CDN propagation delays. [#82]
 
 ### Bug Fixes
 

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -56,7 +56,7 @@ fi
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod trunk push ${COCOAPODS_FLAGS[*]} "$PODSPEC_PATH"
+bundle exec pod trunk push "${COCOAPODS_FLAGS[@]}" "$PODSPEC_PATH"
 
 if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
   cache_cocoapods_specs_repo

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -44,7 +44,7 @@ if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
 	patch-cocoapods
 fi
 
-if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
+if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
 	# When using --synchronous to support pushing co-dependant podspecs one after the other,
 	# Cocoapods will use the master spec repo to avoid being dependant on CDN propagation time
 	# when validating a podspec against another, recently-deployed pod.
@@ -58,6 +58,6 @@ xcrun simctl list >> /dev/null
 
 bundle exec pod trunk push "${COCOAPODS_FLAGS[@]}" "$PODSPEC_PATH"
 
-if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
+if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
   cache_cocoapods_specs_repo
 fi

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -1,10 +1,29 @@
 #!/bin/bash -eu
 
+# Usage: publish_pod [OPTIONS] PODSPEC_PATH
+#
+# OPTIONS:
+#  `--patch-cocoapods`:
+#     Apply a patch to work around issues with older deployment targets — see https://github.com/CocoaPods/CocoaPods/issues/12033
+#  `--allow-warnings`, `--synchronous`:
+#     Those options are passed to `pod trunk push` verbatim.
+#
+# Note: Use `--synchronous` if you have co-dependant podspecs in your repo and need to publish multiple pods at the same time.
+# Without this option, since the first pod you push will take time to propagate thru the CocoaPods CDNs, attempting to push
+# the other dependant pod(s) in your repo might fail to find the first pushed pod until it has propagated thru CDNs.
+#
+
 PATCH_COCOAPODS="false"
+COCOAPODS_FLAGS=(--verbose)
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		--patch-cocoapods)
+			PATCH_COCOAPODS="true"
+			;;
+		--allow-warnings | --synchronous)
+			COCOAPODS_FLAGS+=("$1")
+			;;
 		*) break ;;
 	esac
 	shift
@@ -25,8 +44,20 @@ if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
 	patch-cocoapods
 fi
 
+if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
+	# When using --synchronous to support pushing co-dependant podspecs one after the other,
+	# Cocoapods will use the master spec repo to avoid being dependant on CDN propagation time
+	# when validating a podspec against another, recently-deployed pod.
+	# The master spec repo is pretty large to clone though, so using cache for it is important
+	restore_cache "$BUILDKITE_PIPELINE_SLUG-specs-repos"
+fi
+
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod trunk push --verbose "$PODSPEC_PATH"
+bundle exec pod trunk push ${COCOAPODS_FLAGS[*]} "$PODSPEC_PATH"
+
+if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
+  cache_cocoapods_specs_repo
+fi

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -1,14 +1,45 @@
 #!/bin/bash -eu
 
+# Usage: validate_podspec [OPTIONS] [PODSPEC(S)_PATH(S)...] 
+#
+#  - If no `PODSPEC_PATH` provided, will lint all `*.podspec` files found
+#  - By default, the linting of each podspec will `--include-podspecs=*.podspec` any other podspec
+#    found in the root of the repo, in order to support repos containing co-dependant pods which
+#    needs to be linted and pushed in concert
+#
+# OPTIONS:
+#  `--patch-cocoapods`:
+#     Apply a patch to work around issues with older deployment targets — see https://github.com/CocoaPods/CocoaPods/issues/12033
+#  `--allow-warnings`, `--sources=…`, `--private`, `--include-podspecs=…`, `--external-podspecs=…`:
+#     Those options are passed to `pod lib lint` verbatim
+#
+
 PATCH_COCOAPODS="false"
+COCOAPODS_FLAGS=(--verbose --fail-fast)
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		--patch-cocoapods)
+		  PATCH_COCOAPODS="true"
+			;;
+		--allow-warnings | --sources=* | --private | --include-podspecs=* | --external-podspecs=*)
+			COCOAPODS_FLAGS+=("$1")
+			;;
 		*) break ;;
 	esac
 	shift
 done
+
+if [[ ! "${COCOAPODS_FLAGS[*]}" =~ --include-podspecs=* ]]; then
+	# By default, and if that flag was not already provided explicitly, include all other podspecs present
+	# in the same repo as part of validation, so that if a repo contains multiple co-dependant podspecs,
+	# validation will use the local podspecs of those co-dependant pods when validating each individual pod.
+	#
+	# Note: `pod lib lint` considers it invalid to provide that parameter multiple times, hence testing for it first.
+	# Note: If a client needs to override this to make sure _not_ to include any other podspec for some special case
+	# or reason, one can pass `--include-podspecs=""`
+  COCOAPODS_FLAGS+=("--include-podspecs=*.podspec")
+fi
 
 echo "--- :rubygems: Setting up Gems"
 install_gems
@@ -29,4 +60,4 @@ echo "--- :microscope: Validate Podspec"
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod lib lint --verbose --fail-fast
+bundle exec pod lib lint ${COCOAPODS_FLAGS[*]} -- "$@"

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -60,4 +60,4 @@ echo "--- :microscope: Validate Podspec"
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod lib lint ${COCOAPODS_FLAGS[*]} -- "$@"
+bundle exec pod lib lint "${COCOAPODS_FLAGS[@]}" -- "$@"


### PR DESCRIPTION
This allows our `validate_podspec` and `publish_pod` helpers to support additional flags to forward to the `pod` commands they wrap:

### `validate_podspec`

 - Add support for `--allow-warnings`, `--sources=…`, `--private`, `--include-podspecs=…`, `--external-podspecs=…`
 - The command now automatically adds `--include-podspecs="*.podspec"` to the call if not provided explicitly, in order to support repos that contains multiple co-dependant `.podspec` where one needs the other(s) to be able to validate(†).

### `publish_pod`

 - Add support for `--allow-warnings` and `--synchronous`

## Why?

The main goal is to support repos containing multiple co-dependant `podspecs`.
Examples include [the Gravatar SDK having both `Gravatar` & `GravatarUI`](https://a8c.slack.com/archives/CC7L49W13/p1712044283064279), or [`WordPress-Aztec-iOS` and `WordPress-Editor-iOS`](https://a8c.slack.com/archives/CC7L49W13/p1711030206956679?thread_ts=1711026617.605489&cid=CC7L49W13).

In those cases:
 - The validation of one pod might require to include the other pod too in order for the linting to not fail compilation (hence the need for `--include-podspecs=…`)
 - The `pod trunk push` requires `--synchronous` otherwise the push of the first pod will succeed, but when trying to push the second pod which has the first one as a dependency, it won't be able to find the newly-pushed first pod it depends on, because it would not have propagated to the CocoaPods' CDNs yet

## Testing

I've [tested those changes by doing a dummy `1.0.1-alpha` tag / version on the `Gravatar-SDK-iOS` repo after making it point to this branch of the CI_TOOLKIT plugin](https://github.com/Automattic/Gravatar-SDK-iOS/pull/147#issuecomment-2032367149).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
