### PR TITLE
Fix typo in publish_pods that makes it crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.2.1
+
+### Bug Fixes
+
+ - Fix crash in recent update of the `publish_pod` implementation. [#84]
+
 ## 3.2.0
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.2.0:
+      - automattic/a8c-ci-toolkit#3.2.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.2.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.2.1`.
 
 ## Configuration
 

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -59,5 +59,5 @@ xcrun simctl list >> /dev/null
 bundle exec pod trunk push "${COCOAPODS_FLAGS[@]}" "$PODSPEC_PATH"
 
 if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
-  cache_cocoapods_specs_repo
+  cache_cocoapods_specs_repos
 fi


### PR DESCRIPTION
In #82 we updated `publish_pod` to support `--synchronous`. In that code, we made a typo on the call to `cache_cocoapods_specs_repos`, which [makes the action crash](https://buildkite.com/automattic/gravatar-sdk-ios/builds/405#018ea897-18e0-4d2b-9ac3-418bc7831c71/255-2121).
This went unnoticed during our tests because that only applies to subsequent runs (cache).

This PR fixes the typo, and already prepares the `CHANGELOG.md` to bump the version to `3.2.1`, so that we're ready to release this as a hotfix.