### PR TITLE
Fix `publish_pod`, take 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.2.2
+
+### Bug Fixes
+
+ - Fix crash in recent update of the `publish_pod` implementation — 2nd attempt [#85]
+
 ## 3.2.1
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.2.1:
+      - automattic/a8c-ci-toolkit#3.2.2:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.2.1`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.2.2`.
 
 ## Configuration
 

--- a/bin/cache_cocoapods_specs_repos
+++ b/bin/cache_cocoapods_specs_repos
@@ -1,8 +1,12 @@
 #!/bin/bash -eu
 
-# Follow the typical pod installation process...
-bundle exec pod install --repo-update --verbose
-
-# ...then overwrite the cache for future jobs to use
+# Update CocoaPods's master specs repo (used when you don't use the CDN)
+bundle exec pod repo update --verbose
 save_cache ~/.cocoapods "$BUILDKITE_PIPELINE_SLUG-specs-repos" --force
-save_cache ~/Library/Caches/CocoaPods/ "$BUILDKITE_PIPELINE_SLUG-global-pod-cache" --force
+
+if [ -f Podfile ]; then
+  # Update the cache of the Pods used by the repo.
+  # Skip if the repo doesn't have a `Podfile` (e.g. lib repo with only a `.podspec`)
+  bundle exec pod install --verbose
+  save_cache ~/Library/Caches/CocoaPods/ "$BUILDKITE_PIPELINE_SLUG-global-pod-cache" --force
+fi

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -59,5 +59,5 @@ xcrun simctl list >> /dev/null
 bundle exec pod trunk push "${COCOAPODS_FLAGS[@]}" "$PODSPEC_PATH"
 
 if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
-  cache_cocoapods_specs_repos
+  save_cache ~/.cocoapods "$BUILDKITE_PIPELINE_SLUG-specs-repos" --force
 fi

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -44,20 +44,8 @@ if [[ "${PATCH_COCOAPODS}" ==  'true' ]]; then
 	patch-cocoapods
 fi
 
-if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
-	# When using --synchronous to support pushing co-dependant podspecs one after the other,
-	# Cocoapods will use the master spec repo to avoid being dependant on CDN propagation time
-	# when validating a podspec against another, recently-deployed pod.
-	# The master spec repo is pretty large to clone though, so using cache for it is important
-	restore_cache "$BUILDKITE_PIPELINE_SLUG-specs-repos"
-fi
-
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
 bundle exec pod trunk push "${COCOAPODS_FLAGS[@]}" "$PODSPEC_PATH"
-
-if [[ "${COCOAPODS_FLAGS[*]}" =~ --synchronous ]]; then
-  save_cache ~/.cocoapods "$BUILDKITE_PIPELINE_SLUG-specs-repos" --force
-fi


### PR DESCRIPTION
Second attempt after #84 and the `3.2.1` hotfix, that ended up [taking forever trying and failing to `restore_cache` and led to canceled build](https://buildkite.com/automattic/gravatar-sdk-ios/builds/424#018eaa6b-9040-43e8-8119-0361a843b483/6-8)

# What / Why

- Fix `cache_cocoapods_specs_repo` implementation to not try to `pod install` if there's no `Podfile` (e.g. lib repo and not app repo)—yet to still `pod repo update` in all cases
- `publish_pod`: Remove the code around master repo cache altogether when `--synchronous` is used.

Our `save_cache` / `restore_cache` helpers seem to have deeper implementation issues, especially `restore_cache` seems to try to extract the tarball of the cache in `Users/builder/.cocoapods` instead of `/Users/builder/.cocoapods`, leading to tons of `Write to restore size failed` error messages in logs (one for each files, and there is **a ton** of individual files in the master spec repo) and in the end the action taking forever… to end up not having restored any of the cached `~/.cocoapods` repos and files after all, making it useless.

We might want to fix the `save_cache`/`restore_cache` logic at some point later(†). In the meantime, we need to ship the hotfix to make `publish_pod` work again and allow repos like Gravatar to publish new versions of their pods without being blocked.

---

_(†) There seems to already be some logic around this with `--use_relative_path_in_tar` option on `save_cache` which makes it use `tar … -C …`, but this is only used by `install_swiftpm_dependencies` so far; maybe just adding that flag during the saving of `~/.cocoapods` would be enough, but that's something to try for another time, when there will be more time to investigate and less fires to put out_ 😅 