### PR TITLE
Add allow warnings flag to publish_private_pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Make `publish_private_pod` support `--allow-warnings`. [#86]
 
 ### Bug Fixes
 

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -1,10 +1,15 @@
 #!/bin/bash -eu
 
 PATCH_COCOAPODS="false"
+COCOAPODS_FLAGS=(--verbose)
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		--patch-cocoapods) PATCH_COCOAPODS="true" ;;
+		--patch-cocoapods)
+			PATCH_COCOAPODS="true" ;;
+		--allow-warnings)
+			COCOAPODS_FLAGS+=("$1")
+			;;
 		*) break ;;
 	esac
 	shift
@@ -34,4 +39,4 @@ fi
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
 
-bundle exec pod repo push "$PRIVATE_SPECS_REPO" "$PODSPEC_PATH"
+bundle exec pod repo push "${COCOAPODS_FLAGS[@]}" "$PRIVATE_SPECS_REPO" "$PODSPEC_PATH"

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -6,7 +6,8 @@ COCOAPODS_FLAGS=(--verbose)
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		--patch-cocoapods)
-			PATCH_COCOAPODS="true" ;;
+			PATCH_COCOAPODS="true"
+                        ;;
 		--allow-warnings)
 			COCOAPODS_FLAGS+=("$1")
 			;;


### PR DESCRIPTION
Similar to https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/82, this PR adds the `--allow-warnings` flag to another cocoapod command `publish_private_pod`, which we may need to use in some libraries.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
