### PR TITLE
Add cocoapod flags to another command

### DIFF
--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -1,5 +1,13 @@
 #!/bin/bash -eu
 
+# Usage: publish_private_pod [OPTIONS] PODSPEC_PATH PRIVATE_SPECS_REPO DEPLOY_KEY
+#
+# OPTIONS:
+#  `--patch-cocoapods`:
+#     Apply a patch to work around issues with older deployment targets — see https://github.com/CocoaPods/CocoaPods/issues/12033
+#  `--allow-warnings`:
+#     Allow warnings in `pod repo push`.
+
 PATCH_COCOAPODS="false"
 COCOAPODS_FLAGS=(--verbose)
 

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -15,7 +15,7 @@ while [[ "$#" -gt 0 ]]; do
 	case $1 in
 		--patch-cocoapods)
 			PATCH_COCOAPODS="true"
-                        ;;
+			;;
 		--allow-warnings)
 			COCOAPODS_FLAGS+=("$1")
 			;;


### PR DESCRIPTION
Following up https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/86#issuecomment-2043868041

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
