### PR TITLE
Prepare Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 3.3.0
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
 - Make `publish_private_pod` support `--allow-warnings`. [#86]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,21 +50,13 @@ _None._
 
 ## 3.3.0
 
-### Breaking Changes
-
-_None._
-
 ### New Features
 
 - Make `publish_private_pod` support `--allow-warnings`. [#86]
 
-### Bug Fixes
-
-_None._
-
 ### Internal Changes
 
-- Fixed Ruby, RuboCop and RSpec versions on CI
+- Fixed Ruby, RuboCop and RSpec versions on CI [#88]
 
 ## 3.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Fixed Ruby, RuboCop and RSpec versions on CI
 
 ## 3.2.2
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ shellcheck:
 
 rubocop:
 	@echo ~~~ 🕵️ Rubocop
-	$(docker_run) ruby:2.7.4 /bin/bash -c \
-	  "gem install --silent rubocop && rubocop -A tests/test-that-all-files-are-executable.rb"
+	$(docker_run) ruby:3.2.2 /bin/bash -c \
+	  "gem install --silent rubocop -v 1.62.1 && rubocop -A tests/test-that-all-files-are-executable.rb"
 
 buildkite-plugin-test:
 	@echo ~~~ 🔬 Plugin Tester
@@ -25,5 +25,5 @@ buildkite-plugin-test:
 
 rspec:
 	@echo ~~~ 🔬 Rspec
-	$(docker_run) ruby:2.7.4 /bin/bash -c \
-	  "gem install --silent rspec && rspec tests/test-that-all-files-are-executable.rb"
+	$(docker_run) ruby:3.2.2 /bin/bash -c \
+	  "gem install --silent rspec -v 3.13.0 && rspec tests/test-that-all-files-are-executable.rb"

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.2.2:
+      - automattic/a8c-ci-toolkit#3.3.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.2.2`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.3.0`.
 
 ## Configuration
 


### PR DESCRIPTION
This version contains:
- Update to make `publish_private_pod` support `--allow-warnings`: #86
- Fixing Ruby, RuboCop and RSpec versions on CI (added on this PR, #88)
