### PR TITLE
Update `swiftlint_version` RegExp to check for top-level node

### DIFF
--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -2,7 +2,7 @@
 
 echo "--- :swift: Running SwiftLint"
 
-SWIFTLINT_VERSION=$(<.swiftlint.yml awk '/swiftlint_version: / {print $2}')
+SWIFTLINT_VERSION=$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')
 SWIFTLINT_CMD="docker run --rm -v $PWD:/workspace -w /workspace ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION swiftlint"
 
 set +e


### PR DESCRIPTION
This comes from a comment @AliSoftware left in a private repo.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – N.A.
