### PR TITLE
Limit the SwiftLint arguments to "--strict" and "--lenient"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Restrict the possible `run_swiftlint` command arguments to "--strict" and "--lenient" [#90]
 
 ## 3.3.0
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -4,10 +4,15 @@ echo "--- :swift: Running SwiftLint"
 
 SWIFTLINT_ARGUMENTS=(--quiet --reporter relative-path)
 
-if [ "$1" == "--strict" ] || [ "$1" == "--lenient" ]; then
-  SWIFTLINT_ARGUMENTS+=("$1")
-  shift
-fi
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --strict | --lenient)
+      SWIFTLINT_ARGUMENTS+=("$1")
+      shift
+      ;;
+    *) break ;;
+  esac
+done
 
 if [[ -n $1 ]]; then
   echo "Error: invalid arguments."

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -1,30 +1,25 @@
 #!/bin/bash -eu
 
-validation_error() {
+echo "--- :swift: Running SwiftLint"
+
+SWIFTLINT_ARGUMENTS=(--quiet --reporter relative-path)
+
+if [ "$1" == "--strict" ] || [ "$1" == "--lenient" ]; then
+  SWIFTLINT_ARGUMENTS+=("$1")
+  shift
+fi
+
+if [[ -n $1 ]]; then
   echo "Error: invalid arguments."
   echo "Usage: $0 [--strict | --lenient]"
   exit 1
-}
-
-echo "--- :swift: Running SwiftLint"
-
-SWIFTLINT_ARGUMENT=""
-
-if [ "$#" -eq 1 ]; then
-  if [ "$1" == "--strict" ] || [ "$1" == "--lenient" ]; then
-    SWIFTLINT_ARGUMENT=$1
-  else
-    validation_error
-  fi
-elif [ "$#" -gt 1 ]; then
-  validation_error
 fi
 
-SWIFTLINT_VERSION=$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')
-SWIFTLINT_CMD="docker run --rm -v $PWD:/workspace -w /workspace ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION swiftlint"
+SWIFTLINT_VERSION="$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')"
+SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION" swiftlint)
 
 set +e
-SWIFTLINT_OUTPUT=$($SWIFTLINT_CMD lint --quiet "$SWIFTLINT_ARGUMENT" --reporter relative-path)
+SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")
 SWIFTLINT_EXIT_STATUS=$?
 set -e
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -1,12 +1,30 @@
 #!/bin/bash -eu
 
+validation_error() {
+  echo "Error: invalid arguments."
+  echo "Usage: $0 [--strict | --lenient]"
+  exit 1
+}
+
 echo "--- :swift: Running SwiftLint"
+
+SWIFTLINT_ARGUMENT=""
+
+if [ "$#" -eq 1 ]; then
+  if [ "$1" == "--strict" ] || [ "$1" == "--lenient" ]; then
+    SWIFTLINT_ARGUMENT=$1
+  else
+    validation_error
+  fi
+elif [ "$#" -gt 1 ]; then
+  validation_error
+fi
 
 SWIFTLINT_VERSION=$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')
 SWIFTLINT_CMD="docker run --rm -v $PWD:/workspace -w /workspace ghcr.io/realm/swiftlint:$SWIFTLINT_VERSION swiftlint"
 
 set +e
-SWIFTLINT_OUTPUT=$($SWIFTLINT_CMD lint --quiet "$@" --reporter relative-path)
+SWIFTLINT_OUTPUT=$($SWIFTLINT_CMD lint --quiet "$SWIFTLINT_ARGUMENT" --reporter relative-path)
 SWIFTLINT_EXIT_STATUS=$?
 set -e
 


### PR DESCRIPTION
For security, this PR restricts the possible arguments to the `run_swiftlint` command to `--strict` and `--lenient`, which are the ones currently in use by the apps. More arguments can be added if the need comes up in the future.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
