### PR TITLE
Prepare Release `3.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,14 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## 3.4.0
+
+### Internal Changes
+
 - Restrict the possible `run_swiftlint` command arguments to "--strict" and "--lenient" [#90]
+- Update `swiftlint_version` RegExp to check for top-level node [#89]
 
 ## 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.3.0:
+      - automattic/a8c-ci-toolkit#3.4.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.3.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.4.0`.
 
 ## Configuration
 


### PR DESCRIPTION
Prepare release `3.4.0` containing:
- https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/90
- https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/89 

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
