### PR TITLE
Fix for the `unbound variable` error seen on `run_swiftlint` version `3.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.4.1
+
+### Bug Fixes
+
+- Fix for the unbound variable error seen on `run_swiftlint` [#92]
+
 ## 3.4.0
 
 ### Internal Changes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.4.0:
+      - automattic/a8c-ci-toolkit#3.4.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.4.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.4.1`.
 
 ## Configuration
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -14,7 +14,7 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-if [[ -n ${1+x} ]]; then
+if [[ $# -gt 0 ]]; then
   echo "Error: invalid arguments."
   echo "Usage: $0 [--strict | --lenient]"
   exit 1

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -14,7 +14,7 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-if [[ -n $1 ]]; then
+if [[ -n ${1+x} ]]; then
   echo "Error: invalid arguments."
   echo "Usage: $0 [--strict | --lenient]"
   exit 1


### PR DESCRIPTION
This is a fix for the error
```bash
run_swiftlint: line 17: $1: unbound variable
```
This error was seen when running `run_swiftlint` from Ruby's `system()` call [on CI](https://buildkite.com/automattic/wordpress-ios/builds/22327#018f7871-c7a1-449a-b3cf-c9bf2051f2cc/88-89).

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
