### PR TITLE
Fix `hash_directory` helper to be portable

### DIFF
--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -18,4 +18,4 @@ fi
 # - Run `sha256sum` on each file found – the `+` flag does it in parallel for a huge speed boost.
 # - Sort the files by filename for deterministic hashing
 # - Take the hash of all of the output hashes (and file paths)
-find "$DIRECTORY_PATH" -type f -exec $sha_command "{}" \+ | sort -k 2 | $sha_command | cut -f1 -d " "
+find "${DIRECTORY_PATH%/}" -type f -exec $sha_command "{}" \+ | sort -k 2 | $sha_command | cut -f1 -d " "

--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -9,13 +9,13 @@ fi
 
 # `shasum` is available on only macOS
 if command -v shasum &> /dev/null; then
-  sha_command='shasum -a 256'
+  sha_command=(shasum -a 256)
 else
-  sha_command='sha256sum'
+  sha_command=(sha256sum)
 fi
 
 # - Find all files in the given directory
 # - Run `sha256sum` on each file found – the `+` flag does it in parallel for a huge speed boost.
 # - Sort the files by filename for deterministic hashing
 # - Take the hash of all of the output hashes (and file paths)
-find "${DIRECTORY_PATH%/}" -type f -exec $sha_command "{}" \+ | sort -k 2 | $sha_command | cut -f1 -d " "
+find "${DIRECTORY_PATH%/}" -type f -exec "${sha_command[@]}" "{}" \+ | sort -k 2 | "${sha_command[@]}" | cut -f1 -d " "

--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -7,8 +7,15 @@ if [ -z "$1" ]; then
 	exit 1
 fi
 
+# `shasum` is available on only macOS
+if command -v shasum &> /dev/null; then
+  sha_command='shasum -a 256'
+else
+  sha_command='sha256sum'
+fi
+
 # - Find all files in the given directory
 # - Run `sha256sum` on each file found – the `+` flag does it in parallel for a huge speed boost.
 # - Sort the files by filename for deterministic hashing
 # - Take the hash of all of the output hashes (and file paths)
-find "$DIRECTORY_PATH" -type f -exec sha256sum "{}" \+ | sort -k 2 | shasum -a 256 | cut -f1 -d " "
+find "$DIRECTORY_PATH" -type f -exec $sha_command "{}" \+ | sort -k 2 | $sha_command | cut -f1 -d " "

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -7,11 +7,11 @@ fi
 
 # `shasum` is available on only macOS
 if command -v shasum &> /dev/null; then
-  sha_command='shasum -a 256'
+  sha_command=(shasum -a 256)
 else
-  sha_command='sha256sum'
+  sha_command=(sha256sum)
 fi
 
 # Both `shasum` and `sha256sum` will print the hash and the file name (`$1`).
 # We only care about the hash, so we use `cut` to extract it.
-$sha_command "$1" | cut -f1 -d " "
+"${sha_command[@]}" "$1" | cut -f1 -d " "


### PR DESCRIPTION
Fixes https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/issues/93

## Testing Instructions

In a Terminal on a Mac, `cd` to the root of the working directory of this repo, then:
 - Test `hash_directory`:
    - Run `bin/hash_directory bin/`, and verify that it outputs the hash `24f38e4d7a8db6137b69807fa86e70ea6ba54b78e3441e6b52d55e22cedf5b3f`
    - Run `bin/hash_directory bin` (i.e. without the ending `/`) and verify that it outputs the exact same hash
    - Run `docker run --rm -it -w /workdir -v "$(pwd)":/workdir ubuntu bin/hash_directory bin/` and verify it works and still outputs the same hash
    - Run `docker run --rm -it -w /workdir -v "$(pwd)":/workdir ubuntu bin/hash_directory bin` (i.e. without the trailing `/` in dir name) and verify it works and still outputs the same hash
 - Test `hash_file`:
    - Run `bin/hash_file bin/annotate_test_failures` and verify it outputs the hash `1c312fe4a57e5f6085fef2c75f2778b528d61ea8129ce9960b8bc10bdc0f8501`
    - Run `docker run --rm -it -w /workdir -v "$(pwd)":/workdir ubuntu bin/hash_file bin/annotate_test_failures` and verify it outputs the same hash