### PR TITLE
Prepare release 3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ _None._
 ## 3.4.2
 
 ### Bug Fixes
-- Fix `hash_directory` helper to be portable [#95]
+
+- Fix `hash_directory` helper, and make it portable (Mac+Linux) [#95]
 
 
 ## 3.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.4.2
+
+### Bug Fixes
+- Fix `hash_directory` helper to be portable [#95]
+
+
 ## 3.4.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ _None._
 
 - Fix `hash_directory` helper, and make it portable (Mac+Linux) [#95]
 
-
 ## 3.4.1
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.4.1:
+      - automattic/a8c-ci-toolkit#3.4.2:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.4.1`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.4.2`.
 
 ## Configuration
 


### PR DESCRIPTION
---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
