### PR TITLE
Add a prefix to Gradle cache scripts

### DIFF
--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_DEPENDENCY_CACHE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."
 

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_DEPENDENCY_CACHE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
 
 echo "Saving Gradle dependency cache..."
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${GRADLE_PROJECT_PREFIX}GRADLE_DEPENDENCY_CACHE"
 
 echo "Saving Gradle dependency cache..."
 


### PR DESCRIPTION
To isolate dependencies cache per-project.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
