### PR TITLE
Refactor `install_swiftpm_dependencies` to allow specifying workspace/scheme/project

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,45 @@
+# For convenience with the many install_swiftpm_dependencies steps, we declare agents and env for macOS in the root, then specialize the fewer remaining steps
+agents:
+  queue: mac
+env:
+  IMAGE_ID: xcode-15.4
+
 steps:
   - label: "🕵️ Lint"
     command: make lint
+    agents:
+      queue: default
 
   - label: "🔬 Test"
     command: make test
+    agents:
+      queue: default
+
+  - group: ":swift: install_swiftpm_dependencies Tests"
+    steps:
+      - label: ":swift: Standalone Swift Package - Autodetect"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_package_automatic.sh
+
+      - label: ":swift: Standalone Swift Package - Explicit"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_package_explicit.sh
+
+      - label: ":xcode: Xcode Project - Autodetect"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_project_automatic.sh
+
+      - label: ":xcode: Xcode Project - Explicit"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_project_explicit.sh
+
+      - label: ":xcode: Xcode Project - No Package.resolved"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_project_no_package.sh
+
+      - label: ":xcode: Xcode Workspace - Autodetect"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_automatic.sh
+
+      - label: ":xcode: Xcode Workspace - Explicit"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_explicit.sh
+
+      - label: ":xcode: Xcode Workspace and Project - Autodetect"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_automatic.sh
+
+      - label: ":xcode: Xcode Workspace and Project - Explicit"
+        command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_explicit.sh

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -48,10 +48,10 @@ if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "tru
   FOUND_ROOT_WORKSPACE_PATHS=(*.xcworkspace)
   if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.swift" ]]; then
     XCWORKSPACE_PATH="${FOUND_ROOT_WORKSPACE_PATHS[0]}"
-    echo " --> Found a single \`.xcworkspace\` file and no \`Package.swift\` in the root of the repo."
+    echo " --> Found a single \`.xcworkspace\` file, and no \`Package.swift\` in the root of the repo."
     echo "     Defaulting to \`--workspace \"${XCWORKSPACE_PATH}\"\`."
   elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.swift" ]]; then
-    echo " --> Found a \`Package.swift\` and no root \`.xcworkspace\` in the root of the repo."
+    echo " --> Found a \`Package.swift\`, and no \`.xcworkspace\` in the root of the repo."
     echo "     Defaulting to \`--use-spm\`"
     USE_SPM=true
   else

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -103,7 +103,7 @@ if [[ -d "${XCWORKSPACE_PATH}" ]]; then
   echo "~~~ Resolving Swift Packages with \`xcodebuild\`"
   if [[ -z "${SCHEME_NAME}" ]]; then
     SCHEME_NAME=$(xcodebuild -workspace "${XCWORKSPACE_PATH}" -onlyUsePackageVersionsFromResolvedFile -skipPackageUpdates -list | sed -n '/Schemes:/{n;s/^ *//p;}')
-    echo "No \`--scheme\` parameter provided; assuming the first one found (as it shouldn't matter in practice?): \`${SCHEME_NAME}\`"
+    echo "No \`--scheme\` parameter provided. Using the first one found in the list: \`${SCHEME_NAME}\`"
   fi
   echo "Using -workspace \"${XCWORKSPACE_PATH}\" -scheme \"${SCHEME_NAME}\""
   xcodebuild -workspace "${XCWORKSPACE_PATH}" -scheme "${SCHEME_NAME}" -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -3,7 +3,7 @@
 print_usage() {
   echo "Usage:"
   echo "  Using the \`Package.resolved\` of an Xcode \`.xworkspace\`:"
-  echo "    $0 --workspace PATH --scheme NAME"
+  echo "    $0 --workspace PATH"
   echo "  Using the \`Package.resolved\` of an Xcode \`.xcodeproj\`:"
   echo "    $0 --project PATH"
   echo "  Using the \`Package.resolved\` at the root, managed by \`swift package\` instead of Xcode:"
@@ -12,38 +12,33 @@ print_usage() {
 
 # Parse input parameters
 XCWORKSPACE_PATH=
-SCHEME_NAME=
 XCODEPROJ_PATH=
 USE_SPM=false
-while [[ "$#" -gt 0 ]]; do
-  case $1 in
-    --workspace)
-      XCWORKSPACE_PATH="$2"
-      shift
-      ;;
-    --scheme)
-      SCHEME_NAME=$2
-      shift
-      ;;
-    --project)
-      XCODEPROJ_PATH=$2
-      shift
-      ;;
-    --use-spm)
-      USE_SPM=true
-      ;;
-    -h|--help)
-      print_usage
-      exit 0
-      ;;
-    *)
-      echo "Unknown option or unexpected argument: $1"
-      print_usage
-      exit 2
-      ;;
-  esac
-  shift
-done
+
+case ${1:-} in
+  --workspace)
+    XCWORKSPACE_PATH="$2"
+    shift; shift
+    ;;
+  --project)
+    XCODEPROJ_PATH=$2
+    shift; shift
+    ;;
+  --use-spm)
+    USE_SPM=true
+    shift
+    ;;
+  -h|--help)
+    print_usage
+    exit 0
+    ;;
+esac
+
+if [[ "$#" -gt 0 ]]; then
+  echo "Unexpected extra arguments: $@" >&2
+  print_usage
+  exit 2
+fi
 
 SPM_CACHE_LOCATION="$HOME/Library/Caches/org.swift.swiftpm"
 
@@ -56,12 +51,12 @@ if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "tru
     echo " --> Found a single \`.xcworkspace\` file and no \`Package.swift\` in the root of the repo."
     echo "     Defaulting to \`--workspace \"${XCWORKSPACE_PATH}\"\`."
   elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.swift" ]]; then
-    echo " --> Found a \`Package.swift\` at the root of the repo (and no root \`.xcworkspace\`)"
-    echo "     so we are assuming \`--use-spm\`"
+    echo " --> Found a \`Package.swift\` and no root \`.xcworkspace\` in the root of the repo."
+    echo "     Defaulting to \`--use-spm\`"
     USE_SPM=true
   else
-    echo " -!- No valid --workspace & --scheme, or --project, or --use-spm flag provided, and cannot guess which one to use either, so aborting."
-    echo "     Please call $0 with an explicit \`--workspace PATH\` and \`--scheme NAME\`, or \`--project PATH\`, or \`--use-spm\` flag to disambiguate."
+    echo " -!- No valid --workspace, --project or --use-spm flag provided, and cannot guess which one to use either, so aborting."
+    echo "     Please call $0 with an explicit \`--workspace PATH\`, \`--project PATH\` or \`--use-spm\` flag to disambiguate."
     exit 1
   fi
 fi
@@ -101,12 +96,12 @@ add_host_to_ssh_known_hosts github.com
 # Resolve the packages using the correct method
 if [[ -d "${XCWORKSPACE_PATH}" ]]; then
   echo "~~~ Resolving Swift Packages with \`xcodebuild\`"
-  if [[ -z "${SCHEME_NAME}" ]]; then
-    SCHEME_NAME=$(xcodebuild -workspace "${XCWORKSPACE_PATH}" -onlyUsePackageVersionsFromResolvedFile -skipPackageUpdates -list | sed -n '/Schemes:/{n;s/^ *//p;}')
-    echo "No \`--scheme\` parameter provided. Using the first one found in the list: \`${SCHEME_NAME}\`"
-  fi
-  echo "Using -workspace \"${XCWORKSPACE_PATH}\" -scheme \"${SCHEME_NAME}\""
-  xcodebuild -workspace "${XCWORKSPACE_PATH}" -scheme "${SCHEME_NAME}" -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
+  echo "Using -workspace \"${XCWORKSPACE_PATH}\""
+  # Note: we use `-list` as a workaround because otherwise `xcodebuild` complains that using `-workspace` requires to also provide the `-scheme` option
+  # (despite the help page of `xcodebuild` suggesting that it should work without `-scheme`). Since the dependency resolution doesn't really depend on the scheme
+  # and we don't want to have to provide or guess it, using `-list` instead stops making `xcodebuild` complain about `-workspace` not being used in conjunction
+  # with `-scheme` (even if in practice we don't care about the scheme list it returns)
+  xcodebuild -workspace "${XCWORKSPACE_PATH}" -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile -list
 elif [[ -d "${XCODEPROJ_PATH}" ]]; then
   echo "~~~ Resolving Swift Packages with \`xcodebuild\`"
   echo "Using -project \"${XCODEPROJ_PATH}\""

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -35,12 +35,12 @@ case ${1:-} in
 esac
 
 if [[ "$#" -gt 0 ]]; then
-  echo "Unexpected extra arguments: $@" >&2
+  echo "Unexpected extra arguments: $*" >&2
   print_usage
   exit 2
 fi
 
-SPM_CACHE_LOCATION="$HOME/Library/Caches/org.swift.swiftpm"
+SPM_CACHE_LOCATION="${HOME}/Library/Caches/org.swift.swiftpm"
 
 # Try to guess what to do if no option provided explicitly
 if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "true" ]]; then
@@ -78,12 +78,12 @@ fi
 
 # Restore SPM cache if it's available
 echo "~~~ Restoring SPM cache if available"
-PACKAGE_RESOLVED_HASH=$(hash_file "$PACKAGE_RESOLVED_LOCATION")
+PACKAGE_RESOLVED_HASH=$(hash_file "${PACKAGE_RESOLVED_LOCATION}")
 CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}-spm-cache-${PACKAGE_RESOLVED_HASH}"
 
-mkdir -p "$SPM_CACHE_LOCATION"
-cd "$SPM_CACHE_LOCATION"
-restore_cache "$CACHE_KEY"
+mkdir -p "${SPM_CACHE_LOCATION}"
+cd "${SPM_CACHE_LOCATION}"
+restore_cache "${CACHE_KEY}"
 cd -
 
 # This will let Xcode use the system SSH config for downloading packages
@@ -119,8 +119,8 @@ fi
 # certain packages to have the artifacts already present after extracting 
 # cache
 echo "~~~ Cleaning up cache files before saving cache"
-rm -rf "$SPM_CACHE_LOCATION/checkouts" "$SPM_CACHE_LOCATION/artifacts"
+rm -rf "${SPM_CACHE_LOCATION}/checkouts" "${SPM_CACHE_LOCATION}/artifacts"
 
 # If this is the first time we've seen this particular cache key, save it for the future
 echo "~~~ Saving SPM Cache"
-save_cache "$SPM_CACHE_LOCATION" "$CACHE_KEY" false --use_relative_path_in_tar
+save_cache "${SPM_CACHE_LOCATION}" "${CACHE_KEY}" false --use_relative_path_in_tar

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -6,7 +6,7 @@ print_usage() {
   echo "    $0 --workspace PATH --scheme NAME"
   echo "  Using the \`Package.resolved\` of an Xcode \`.xcodeproj\`:"
   echo "    $0 --project PATH"
-  echo "  Using the \`Package.resolved\` at the root, managed by \`swift package\` (and not Xcode)"
+  echo "  Using the \`Package.resolved\` at the root, managed by \`swift package\` instead of Xcode:"
   echo "    $0 --use-spm"
 }
 

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -3,11 +3,11 @@
 print_usage() {
   echo "Usage:"
   echo "  Using the \`Package.resolved\` of an Xcode \`.xworkspace\`:"
-  echo "    $0 --workspace PATH"
+  echo "    ${0##*/} --workspace PATH"
   echo "  Using the \`Package.resolved\` of an Xcode \`.xcodeproj\`:"
-  echo "    $0 --project PATH"
+  echo "    ${0##*/} --project PATH"
   echo "  Using the \`Package.resolved\` at the root, managed by \`swift package\` instead of Xcode:"
-  echo "    $0 --use-spm"
+  echo "    ${0##*/} --use-spm"
 }
 
 # Parse input parameters

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -1,30 +1,91 @@
 #!/bin/bash -eu
 
-CUSTOM_PACKAGE_RESOLVED_PATH=${1-}
-BUILD_TYPE=${2-}
+print_usage() {
+  echo "Usage:"
+  echo "  Using the \`Package.resolved\` of an Xcode \`.xworkspace\`:"
+  echo "    $0 --workspace PATH --scheme NAME"
+  echo "  Using the \`Package.resolved\` of an Xcode \`.xcodeproj\`:"
+  echo "    $0 --project PATH"
+  echo "  Using the \`Package.resolved\` at the root, managed by \`swift package\` (and not Xcode)"
+  echo "    $0 --use-spm"
+}
+
+# Parse input parameters
+XCWORKSPACE_PATH=
+SCHEME_NAME=
+XCODEPROJ_PATH=
+USE_SPM=false
+while [[ "$#" -gt 0 ]]; do
+	case $1 in
+		--workspace)
+			XCWORKSPACE_PATH="$2"
+      shift
+			;;
+		--scheme)
+			SCHEME_NAME=$2
+      shift
+			;;
+    --project)
+      XCODEPROJ_PATH=$2
+      shift
+      ;;
+    --use-spm)
+      USE_SPM=true
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option or unexpected argument: $1"
+      print_usage
+      exit 2
+      ;;
+	esac
+	shift
+done
+
 SPM_CACHE_LOCATION="$HOME/Library/Caches/org.swift.swiftpm"
 
-WORKSPACE_PACKAGE_RESOLVED_PATH=(*.xcworkspace/xcshareddata/swiftpm/Package.resolved)
-ROOT_PACKAGE_RESOLVED_PATH=Package.resolved
+# Try to guess what to do if no option provided explicitly
+if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "true" ]]; then
+  echo "No \`--workspace\`, \`--project\` or \`--use-spm\` flag provided. Trying to guess the correct one to use..."
+  FOUND_ROOT_WORKSPACE_PATHS=(*.xcworkspace)
+  if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.resolved" ]]; then
+    XCWORKSPACE_PATH="${FOUND_ROOT_WORKSPACE_PATHS[0]}"
+    echo " --> Found a single \`.xcworkspace\` file at the root of the repo (and no root \`Package.resolved\`)"
+    echo "     so we are assuming \`--workspace \"${XCWORKSPACE_PATH}\"\`."
+  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.resolved" ]]; then
+    echo " --> Found a \`Package.resolved\` at the root of the repo (and no root \`.xcworkspace\`)"
+    echo "     so we are assuming \`--use-spm\`"
+    USE_SPM=true
+  else
+    echo " -!- No valid --workspace & --scheme, or --project, or --use-spm flag provided, and cannot guess which one to use either, so aborting."
+    echo "     Please call $0 with an explicit \`--workspace PATH\` and \`--scheme NAME\`, or \`--project PATH\`, or \`--use-spm\` flag to desambiguate."
+    exit 1
+  fi
+fi
 
-# Find where Package.resolved is located
-if [[ -n "$CUSTOM_PACKAGE_RESOLVED_PATH" ]]; then
-  PACKAGE_RESOLVED_LOCATION="$CUSTOM_PACKAGE_RESOLVED_PATH"
-elif  [[ -f "${WORKSPACE_PACKAGE_RESOLVED_PATH[0]}" ]]; then
-  BUILD_TYPE="XCODEBUILD"
-  PACKAGE_RESOLVED_LOCATION="${WORKSPACE_PACKAGE_RESOLVED_PATH[0]}"
-elif  [[ -f "$ROOT_PACKAGE_RESOLVED_PATH" ]]; then
-  BUILD_TYPE="SWIFT"
-  PACKAGE_RESOLVED_LOCATION="$ROOT_PACKAGE_RESOLVED_PATH"
-else
-  echo "Unable to find Package.resolved"
+# Find where Package.resolved is located so we can compute the cache key from its hash
+PACKAGE_RESOLVED_LOCATION=
+if [[ -d "${XCWORKSPACE_PATH}" ]]; then
+  PACKAGE_RESOLVED_LOCATION="${XCWORKSPACE_PATH}/xcshareddata/swiftpm/Package.resolved"
+elif [[ -d "${XCODEPROJ_PATH}" ]]; then
+  PACKAGE_RESOLVED_LOCATION="${XCODEPROJ_PATH}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+elif [[ "${USE_SPM}" == "true" ]]; then
+  PACKAGE_RESOLVED_LOCATION="Package.resolved"
+fi
+
+if [[ ! -f "${PACKAGE_RESOLVED_LOCATION}" ]]; then
+  echo "Unable to find \`Package.resolved\` file (${PACKAGE_RESOLVED_LOCATION:-unable to guess path})"
   exit 1
 fi
 
+# Restore SPM cache if it's available
+echo "~~~ Restoring SPM cache if available"
 PACKAGE_RESOLVED_HASH=$(hash_file "$PACKAGE_RESOLVED_LOCATION")
 CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}-spm-cache-${PACKAGE_RESOLVED_HASH}"
 
-# Restore SPM cache if it's available
 mkdir -p "$SPM_CACHE_LOCATION"
 cd "$SPM_CACHE_LOCATION"
 restore_cache "$CACHE_KEY"
@@ -37,17 +98,24 @@ sudo defaults write com.apple.dt.Xcode IDEPackageSupportUseBuiltinSCM YES
 add_host_to_ssh_known_hosts bitbucket.org
 add_host_to_ssh_known_hosts github.com
 
-# Based on the project type, resolve the packages using the correct build type
-if [[ "$BUILD_TYPE" == "XCODEBUILD" ]]; then
-  echo "	Resolving packages with \`xcodebuild\`"
-  xcodebuild -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
-elif [[ "$BUILD_TYPE" == "SWIFT" ]]; then
-  echo "	Resolving packages with \`swift\`"
+# Resolve the packages using the correct method
+if [[ -d "${XCWORKSPACE_PATH}" ]]; then
+  echo "~~~ Resolving Swift Packages with \`xcodebuild\`"
+  if [[ -z "${SCHEME_NAME}" ]]; then
+    SCHEME_NAME=$(xcodebuild -workspace "${XCWORKSPACE_PATH}" -onlyUsePackageVersionsFromResolvedFile -skipPackageUpdates -list | sed -n '/Schemes:/{n;s/^ *//p;}')
+    echo "No \`--scheme\` parameter provided; assuming the first one found (as it shouldn't matter in practice?): \`${SCHEME_NAME}\`"
+  fi
+  echo "Using -workspace \"${XCWORKSPACE_PATH}\" -scheme \"${SCHEME_NAME}\""
+  xcodebuild -workspace "${XCWORKSPACE_PATH}" -scheme "${SCHEME_NAME}" -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
+elif [[ -d "${XCODEPROJ_PATH}" ]]; then
+  echo "~~~ Resolving Swift Packages with \`xcodebuild\`"
+  echo "Using -project \"${XCODEPROJ_PATH}\""
+  xcodebuild -project "${XCODEPROJ_PATH}" -resolvePackageDependencies -onlyUsePackageVersionsFromResolvedFile
+elif [[ "${USE_SPM}" == "true" ]]; then
+  echo "~~~ Resolving packages with \`swift package\`"
   swift package resolve
-else 
-  echo "BUILD_TYPE must be set"
-  exit 1
 fi
+
 
 # `checkouts` can be removed because the system can quickly generate them 
 # instead of needing to download them in the cache each time.
@@ -55,11 +123,9 @@ fi
 # `artifacts` should be removed because it causes issues when downloading 
 # certain packages to have the artifacts already present after extracting 
 # cache
-echo "	Cleaning up cache files before saving cache"
+echo "~~~ Cleaning up cache files before saving cache"
 rm -rf "$SPM_CACHE_LOCATION/checkouts" "$SPM_CACHE_LOCATION/artifacts"
 
 # If this is the first time we've seen this particular cache key, save it for the future
-echo "	Saving SPM Cache"
+echo "~~~ Saving SPM Cache"
 save_cache "$SPM_CACHE_LOCATION" "$CACHE_KEY" false --use_relative_path_in_tar
-
-

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -16,15 +16,15 @@ SCHEME_NAME=
 XCODEPROJ_PATH=
 USE_SPM=false
 while [[ "$#" -gt 0 ]]; do
-	case $1 in
-		--workspace)
-			XCWORKSPACE_PATH="$2"
+  case $1 in
+    --workspace)
+      XCWORKSPACE_PATH="$2"
       shift
-			;;
-		--scheme)
-			SCHEME_NAME=$2
+      ;;
+    --scheme)
+      SCHEME_NAME=$2
       shift
-			;;
+      ;;
     --project)
       XCODEPROJ_PATH=$2
       shift
@@ -41,8 +41,8 @@ while [[ "$#" -gt 0 ]]; do
       print_usage
       exit 2
       ;;
-	esac
-	shift
+  esac
+  shift
 done
 
 SPM_CACHE_LOCATION="$HOME/Library/Caches/org.swift.swiftpm"

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -63,10 +63,10 @@ fi
 
 # Find where Package.resolved is located so we can compute the cache key from its hash
 PACKAGE_RESOLVED_LOCATION=
-if [[ -d "${XCWORKSPACE_PATH}" ]]; then
-  PACKAGE_RESOLVED_LOCATION="${XCWORKSPACE_PATH}/xcshareddata/swiftpm/Package.resolved"
-elif [[ -d "${XCODEPROJ_PATH}" ]]; then
-  PACKAGE_RESOLVED_LOCATION="${XCODEPROJ_PATH}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+if [[ -n "${XCWORKSPACE_PATH}" ]]; then
+  PACKAGE_RESOLVED_LOCATION="${XCWORKSPACE_PATH%/}/xcshareddata/swiftpm/Package.resolved"
+elif [[ -n "${XCODEPROJ_PATH}" ]]; then
+  PACKAGE_RESOLVED_LOCATION="${XCODEPROJ_PATH%/}/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 elif [[ "${USE_SPM}" == "true" ]]; then
   PACKAGE_RESOLVED_LOCATION="Package.resolved"
 fi

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -45,13 +45,21 @@ SPM_CACHE_LOCATION="${HOME}/Library/Caches/org.swift.swiftpm"
 # Try to guess what to do if no option provided explicitly
 if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "true" ]]; then
   echo "No \`--workspace\`, \`--project\` or \`--use-spm\` flag provided. Trying to guess the correct one to use..."
+
+  shopt -s nullglob
   FOUND_ROOT_WORKSPACE_PATHS=(*.xcworkspace)
-  if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.swift" ]]; then
+  FOUND_ROOT_PROJECT_PATHS=(*.xcodeproj)
+
+  if [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.swift" ]]; then
     XCWORKSPACE_PATH="${FOUND_ROOT_WORKSPACE_PATHS[0]}"
     echo " --> Found a single \`.xcworkspace\` file, and no \`Package.swift\` in the root of the repo."
     echo "     Defaulting to \`--workspace \"${XCWORKSPACE_PATH}\"\`."
-  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.swift" ]]; then
-    echo " --> Found a \`Package.swift\`, and no \`.xcworkspace\` in the root of the repo."
+  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && ${#FOUND_ROOT_PROJECT_PATHS[@] } -eq 1 && ! -f "Package.swift" ]]; then
+    XCODEPROJ_PATH="${FOUND_ROOT_PROJECT_PATHS[0]}"
+    echo " --> Found an \`.xcodeproj\`, and no \`Package.swift\` nor \`.xcworkspace\`in the root of the repo."
+    echo "     Defaulting to \`--project \"${XCODEPROJ_PATH}\`"
+  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && ${#FOUND_ROOT_PROJECT_PATHS[@] } -eq 0 && -f "Package.swift" ]]; then
+    echo " --> Found a \`Package.swift\`, and no \`.xcworkspace\` or \`.xcodeproj\` in the root of the repo."
     echo "     Defaulting to \`--use-spm\`"
     USE_SPM=true
   else
@@ -111,15 +119,15 @@ elif [[ "${USE_SPM}" == "true" ]]; then
   swift package resolve
 fi
 
-
-# `checkouts` can be removed because the system can quickly generate them 
+# `checkouts` can be removed because the system can quickly generate them
 # instead of needing to download them in the cache each time.
-# 
-# `artifacts` should be removed because it causes issues when downloading 
-# certain packages to have the artifacts already present after extracting 
+#
+# `artifacts` should be removed because it causes issues when downloading
+# certain packages to have the artifacts already present after extracting
 # cache
 echo "~~~ Cleaning up cache files before saving cache"
 rm -rf "${SPM_CACHE_LOCATION}/checkouts" "${SPM_CACHE_LOCATION}/artifacts"
+echo "Done. Removed checkouts and artifacts subfolders from $SPM_CACHE_LOCATION"
 
 # If this is the first time we've seen this particular cache key, save it for the future
 echo "~~~ Saving SPM Cache"

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -53,15 +53,15 @@ if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "tru
   FOUND_ROOT_WORKSPACE_PATHS=(*.xcworkspace)
   if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.swift" ]]; then
     XCWORKSPACE_PATH="${FOUND_ROOT_WORKSPACE_PATHS[0]}"
-    echo " --> Found a single \`.xcworkspace\` file at the root of the repo (and no root \`Package.swift\`)"
-    echo "     so we are assuming \`--workspace \"${XCWORKSPACE_PATH}\"\`."
+    echo " --> Found a single \`.xcworkspace\` file and no \`Package.swift\` in the root of the repo."
+    echo "     Defaulting to \`--workspace \"${XCWORKSPACE_PATH}\"\`."
   elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.swift" ]]; then
     echo " --> Found a \`Package.swift\` at the root of the repo (and no root \`.xcworkspace\`)"
     echo "     so we are assuming \`--use-spm\`"
     USE_SPM=true
   else
     echo " -!- No valid --workspace & --scheme, or --project, or --use-spm flag provided, and cannot guess which one to use either, so aborting."
-    echo "     Please call $0 with an explicit \`--workspace PATH\` and \`--scheme NAME\`, or \`--project PATH\`, or \`--use-spm\` flag to desambiguate."
+    echo "     Please call $0 with an explicit \`--workspace PATH\` and \`--scheme NAME\`, or \`--project PATH\`, or \`--use-spm\` flag to disambiguate."
     exit 1
   fi
 fi

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -17,11 +17,11 @@ USE_SPM=false
 
 case ${1:-} in
   --workspace)
-    XCWORKSPACE_PATH="$2"
+    XCWORKSPACE_PATH="${2:?you need to provide a value after the --workspace option}"
     shift; shift
     ;;
   --project)
-    XCODEPROJ_PATH=$2
+    XCODEPROJ_PATH=${2:?you need to provide a value after the --project option}
     shift; shift
     ;;
   --use-spm)

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -51,12 +51,12 @@ SPM_CACHE_LOCATION="$HOME/Library/Caches/org.swift.swiftpm"
 if [[ -z "${XCWORKSPACE_PATH}" && -z "${XCODEPROJ_PATH}" && "${USE_SPM}" != "true" ]]; then
   echo "No \`--workspace\`, \`--project\` or \`--use-spm\` flag provided. Trying to guess the correct one to use..."
   FOUND_ROOT_WORKSPACE_PATHS=(*.xcworkspace)
-  if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.resolved" ]]; then
+  if  [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 1 && -d "${FOUND_ROOT_WORKSPACE_PATHS[0]}" && ! -f "Package.swift" ]]; then
     XCWORKSPACE_PATH="${FOUND_ROOT_WORKSPACE_PATHS[0]}"
-    echo " --> Found a single \`.xcworkspace\` file at the root of the repo (and no root \`Package.resolved\`)"
+    echo " --> Found a single \`.xcworkspace\` file at the root of the repo (and no root \`Package.swift\`)"
     echo "     so we are assuming \`--workspace \"${XCWORKSPACE_PATH}\"\`."
-  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.resolved" ]]; then
-    echo " --> Found a \`Package.resolved\` at the root of the repo (and no root \`.xcworkspace\`)"
+  elif [[ ${#FOUND_ROOT_WORKSPACE_PATHS[@]} -eq 0 && -f "Package.swift" ]]; then
+    echo " --> Found a \`Package.swift\` at the root of the repo (and no root \`.xcworkspace\`)"
     echo "     so we are assuming \`--use-spm\`"
     USE_SPM=true
   else

--- a/tests/install_swiftpm_dependencies/Makefile
+++ b/tests/install_swiftpm_dependencies/Makefile
@@ -1,0 +1,4 @@
+regenerate_fixtures:
+	xcodegen generate --spec ./project/project.yml
+	xcodebuild -resolvePackageDependencies -project ./project/Demo.xcodeproj
+	cp ./project/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved ./package_resolved_fixtures/valid.resolved

--- a/tests/install_swiftpm_dependencies/README.md
+++ b/tests/install_swiftpm_dependencies/README.md
@@ -1,0 +1,17 @@
+# Integration tests for `install_swiftpm_dependencies`
+
+This folder contains a variety of Xcode and Swift Package projects to test the behavior of the `install_swiftpm_dependencies` in various configurations.
+
+Note that currently with "testing" we mean: making sure the CI build doesn't fail. There isn't yet an automated setup to verify the correct command behavior.
+
+Also note that the tests are intentionally at the integration / end-to-end level. We could structure `install_swiftpm_dependencies` so that it spits out the `xcodebuild` or `swift` it plans to run and test that, but we would lose important feedback on how `xcodebuild` and `swift` themselves behave.
+Feedback on Apple's tooling behavior is crucial to get, given their known quirks.
+
+## Development
+
+The integration tests use [XcodeGen](https://github.com/yonaskolb/XcodeGen) to code-generate the project files and keep the repository footprint small.
+
+However, by code-generating the xcodeproj file we lose tracking of the `Package.resolved` Xcode generates at build time, which is particularly problematic in CI.
+To compensate for this, we have dedicated automation that tracks a reference `Package.resolved` file for CI to use.
+
+If resolved file format were to change in the future, you can update the reference file via `make regenerate_resolved_fixtures`.

--- a/tests/install_swiftpm_dependencies/package/.gitignore
+++ b/tests/install_swiftpm_dependencies/package/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/tests/install_swiftpm_dependencies/package/Package.resolved
+++ b/tests/install_swiftpm_dependencies/package/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "c908e0d89a41be29a11cf4ce76b34002b6c4863ff5d7eafd623b36c267284b12",
+  "pins" : [
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/ScreenObject",
+      "state" : {
+        "revision" : "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+        "version" : "0.2.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tests/install_swiftpm_dependencies/package/Package.swift
+++ b/tests/install_swiftpm_dependencies/package/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "Demo",
+    products: [
+        .library(
+            name: "Demo",
+            targets: ["Demo"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Automattic/ScreenObject", from: "0.2.3")
+    ],
+    targets: [
+        .target(
+            name: "Demo"),
+        .testTarget(
+            name: "DemoTests",
+            dependencies: ["Demo"]),
+    ]
+)

--- a/tests/install_swiftpm_dependencies/package/Sources/Demo/Demo.swift
+++ b/tests/install_swiftpm_dependencies/package/Sources/Demo/Demo.swift
@@ -1,0 +1,5 @@
+struct Demo {
+    static func sayHello() -> String {
+        "Hello, world!"
+    }
+}

--- a/tests/install_swiftpm_dependencies/package/Tests/DemoTests/DemoTests.swift
+++ b/tests/install_swiftpm_dependencies/package/Tests/DemoTests/DemoTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import Demo
+
+final class DemoTests: XCTestCase {
+    func testHello() throws {
+        XCTAssertEqual(Demo.sayHello(), "Hello, world!")
+    }
+}

--- a/tests/install_swiftpm_dependencies/package_resolved_fixtures/valid.resolved
+++ b/tests/install_swiftpm_dependencies/package_resolved_fixtures/valid.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "5ca84ad21a87cfff30163bd7dd55abded567e0600b5a0adbc80cfe0c687ecc69",
+  "pins" : [
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Automattic/ScreenObject",
+      "state" : {
+        "revision" : "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+        "version" : "0.2.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tests/install_swiftpm_dependencies/project/.gitignore
+++ b/tests/install_swiftpm_dependencies/project/.gitignore
@@ -1,0 +1,5 @@
+# For convenience with the code generation, ignore everything in this folder other that what's required to code-gen and test behavior
+*
+!project.yml
+!Makefile
+!Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved

--- a/tests/install_swiftpm_dependencies/project/Makefile
+++ b/tests/install_swiftpm_dependencies/project/Makefile
@@ -1,0 +1,4 @@
+.DEFAULT_GOAL := generate
+
+generate:
+	xcodegen generate

--- a/tests/install_swiftpm_dependencies/project/project.yml
+++ b/tests/install_swiftpm_dependencies/project/project.yml
@@ -1,0 +1,28 @@
+name: Demo
+options:
+  bundleIdPrefix: com.automattic.tests
+packages:
+  ScreenObject:
+    url: https://github.com/Automattic/ScreenObject
+    from: 0.2.3
+targets:
+  Demo:
+    type: framework
+    platform: iOS
+    sources: [../package/Sources]
+    settings:
+      GENERATE_INFOPLIST_FILE: YES
+    scheme:
+      testTargets: [DemoTests]
+  DemoTests:
+    target: Demo
+    type: bundle.unit-test
+    platform: iOS
+    sources: [../package/Tests/]
+    settings:
+      GENERATE_INFOPLIST_FILE: YES
+      # No need for code signing in this demo, plus, it's the test target
+      CODE_SIGNING_ALLOWED: NO
+    dependencies:
+      - target: Demo
+      - package: ScreenObject

--- a/tests/install_swiftpm_dependencies/test_scripts/run_tests_with_xcodebuild.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/run_tests_with_xcodebuild.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+echo "--- :xcode: Run tests to verify packages have been fetched and are available"
+xcodebuild test \
+  -scheme Demo \
+  -configuration Debug \
+  -destination 'platform=iOS Simulator' \
+  | xcbeautify

--- a/tests/install_swiftpm_dependencies/test_scripts/set_up_environment.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/set_up_environment.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ "${BASH_SOURCE[0]}" -ef "$0" ]; then
+  echo "$0 must be sourced"
+  exit 1
+fi
+
+set -eu
+
+echo "--- :computer: Prepare environment"
+TESTS_LOCATION="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NEW_PATH=$PATH:"$TESTS_LOCATION/../../../bin"
+
+export PATH=$NEW_PATH
+export TESTS_LOCATION

--- a/tests/install_swiftpm_dependencies/test_scripts/test_package_automatic.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_package_automatic.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../package"
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies
+
+echo "--- :xcode: Run tests to verify packages have been fetched and are available"
+swift test

--- a/tests/install_swiftpm_dependencies/test_scripts/test_package_explicit.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_package_explicit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../package"
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies --use-spm
+
+echo "--- :xcode: Run tests to verify packages have been fetched and are available"
+swift test

--- a/tests/install_swiftpm_dependencies/test_scripts/test_project_automatic.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_project_automatic.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../project"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :computer: Copy Package.resolved fixture"
+PROJECT="Demo.xcodeproj"
+XCODE_SPM_PATH="$PROJECT/project.xcworkspace/xcshareddata/swiftpm"
+mkdir -p "$XCODE_SPM_PATH"
+cp "$TESTS_LOCATION/../package_resolved_fixtures/valid.resolved" "$XCODE_SPM_PATH/Package.resolved"
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/test_scripts/test_project_explicit.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_project_explicit.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../project"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :computer: Copy Package.resolved fixture"
+PROJECT="Demo.xcodeproj"
+XCODE_SPM_PATH="$PROJECT/project.xcworkspace/xcshareddata/swiftpm"
+mkdir -p "$XCODE_SPM_PATH"
+cp "$TESTS_LOCATION/../package_resolved_fixtures/valid.resolved" "$XCODE_SPM_PATH/Package.resolved"
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies --project $PROJECT
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/test_scripts/test_project_no_package.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_project_no_package.sh
@@ -1,0 +1,42 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../project"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+# Notice we do not set up the fixture Package.resolved.
+# As such, we expect the call to the plugin to fail.
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+PROJECT=Demo.xcodeproj
+LOGS_PATH=logs
+set +e
+install_swiftpm_dependencies --project $PROJECT 2>&1 | tee "$LOGS_PATH"
+CMD_EXIT_STATUS=$?
+set -e
+
+EXPECTED="Unable to find \`Package.resolved\` file ($PROJECT/project.xcworkspace/xcshareddata/swiftpm/Package.resolved)"
+
+if [[ $CMD_EXIT_STATUS -eq 0 ]]; then
+  echo "+++ :x: install_swiftpm_dependencies unexpectedly succeeded without a Package.resolved in the project folder!"
+  echo "Expected: $EXPECTED"
+  echo "Got: $(cat $LOGS_PATH)"
+  exit 1
+else
+  if grep -qF "$EXPECTED" "$LOGS_PATH"; then
+    echo "^^^ +++"
+    echo "+++ :white_check_mark: install_swiftpm_dependencies failed as expected because there is no Package.resolved in the project folder."
+  else
+    echo "+++ :x: install_swiftpm_dependencies failed, but the message it printed is not what we expected."
+    echo "Expected: $EXPECTED"
+    echo "Got: $(cat $LOGS_PATH)"
+    exit 1
+  fi
+fi

--- a/tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_automatic.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_automatic.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../workspace_and_project"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_explicit.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_explicit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../workspace_and_project"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies --workspace Demo.xcworkspace
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/test_scripts/test_workspace_automatic.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_workspace_automatic.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../workspace"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/test_scripts/test_workspace_explicit.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/test_workspace_explicit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/set_up_environment.sh"
+
+echo "--- :computer: Jump to test folder"
+pushd "$TESTS_LOCATION/../workspace"
+
+echo "--- :computer: Generate project"
+brew install xcodegen
+make
+
+echo "--- :wrench: Run install_swiftpm_dependencies"
+install_swiftpm_dependencies --workspace Demo.xcworkspace
+
+"$TESTS_LOCATION/run_tests_with_xcodebuild.sh"

--- a/tests/install_swiftpm_dependencies/workspace/.gitignore
+++ b/tests/install_swiftpm_dependencies/workspace/.gitignore
@@ -1,0 +1,5 @@
+# For convenience with the code generation, ignore everything other than the Makefile and workspace
+*
+!Makefile
+!*.xcworkspace/
+*.xcworkspace/xcuserdata

--- a/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/contents.xcworkspacedata
+++ b/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:../project/Demo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tests/install_swiftpm_dependencies/workspace/Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "df0bf1b75530ea9424408e39d4acdb54dd26151176343ec90d9352ede0d6529e",
+  "pins" : [
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/automattic/screenobject",
+      "state" : {
+        "revision" : "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+        "version" : "0.2.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tests/install_swiftpm_dependencies/workspace/Makefile
+++ b/tests/install_swiftpm_dependencies/workspace/Makefile
@@ -1,0 +1,2 @@
+generate:
+	xcodegen generate --spec ../project/project.yml

--- a/tests/install_swiftpm_dependencies/workspace_and_project/.gitignore
+++ b/tests/install_swiftpm_dependencies/workspace_and_project/.gitignore
@@ -1,0 +1,5 @@
+# For convenience with the code generation, ignore everything other than the Makefile and workspace
+*
+!Makefile
+!*.xcworkspace/
+*.xcworkspace/xcuserdata

--- a/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/contents.xcworkspacedata
+++ b/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Demo.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/tests/install_swiftpm_dependencies/workspace_and_project/Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "df0bf1b75530ea9424408e39d4acdb54dd26151176343ec90d9352ede0d6529e",
+  "pins" : [
+    {
+      "identity" : "screenobject",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/automattic/screenobject",
+      "state" : {
+        "revision" : "328db56c62aab91440ec5e07cc9f7eef6e26a26e",
+        "version" : "0.2.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/tests/install_swiftpm_dependencies/workspace_and_project/Makefile
+++ b/tests/install_swiftpm_dependencies/workspace_and_project/Makefile
@@ -1,0 +1,5 @@
+generate:
+	# Note: we need to copy the project file in place (as opposed to using --spec)
+	# so that xcodegen can add the scheme for the Demo project into the `Demo.xcworkspace`
+	cp ../project/project.yml .
+	xcodegen generate


### PR DESCRIPTION
## Why?

To solve issues like the one reported in https://github.com/Automattic/pocket-casts-ios/issues/1990

TL;DR: the `install_swiftpm_dependencies` utility was calling `xcodebuild -resolvePackageDependencies` without the `-workspace` flag, thus relying on the `Package.resolved` from the `.xcodeproj` instead of the `.xcworkspace` by default (at least that's how that `xcodebuild` command seems to behave).
This led to us having multiple `Package.resolved` files (one in `xcodeproj`, one in `xcworkspace`, and two sources of truth that were disagreeing with each other, depending on which method we used to resolve the dependencies last (Xcode UI or `xcodebuild` or this a8c-ci-toolkit utility).

## What?

This PR makes some changes to our `install_swiftpm_dependencies` utility so that:
 - The caller can specify `--workspace PATH --scheme NAME` explicitly to resolve dependencies based on an Xcode `.xcworkspace` workspace
    - The `xcodebuild --help` documentation suggests that we should be able to call `xcodebuild -workspace -resolvePackageDependencies` without providing a `-scheme` parameter… but in practice doing so makes `xcodebuild` complain about that parameter missing and exit. Hence why this initial refactoring will expect a `--scheme` to be passed too, even if in practice I'm pretty sure the scheme doesn't have any effect on the packages resolution itself
    - There [might actually be a way to avoid this issue / `xcodebuild` bug and not need to pass `-scheme` when passing `-workspace` after all, by instead passing `-list` instead](#discussion_r1705963616). This might require some more testing to validate it works as expected though (and especially still honors the `-onlyUsePackageVersionsFromResolvedFile` option in those cases too)
 - Or alternatively specify `--project PATH` explicitly to resolve dependencies based on an Xcode lone `.xcodeproj` project
 - Or alternatively explicitly specify `--use-spm` to use `swift package resolve` instead of `xcodebuild` (typically for library repos which don't have an Xcode project and workspace and fully rely on a `Package.swift` file at the root)
 - Improve the logic at attempting to auto-detect the right thing to do when none of the above parameters are provided
    - If there's a single `xcworkspace` at the root of the repo, and no `Package.swift` at the root, use `xcodebuild -workspace`, using (arbitrarily) the first scheme found in that workspace for the `-scheme` parameter of `xcodebuild` (that is documented not to be needed but in practice errors out if not provided—there [might be room for improvement here / hope for not needing this after all though](#discussion_r1705963616)).
    - Otherwise if there's no `xcworkspace` but there's a `Package.swift` file, use `swift package resolve`
 - Ensure that we use `-workspace` when resolving swift dependencies using `xcodebuild` and have the cache key and the dependency resolution both based on the `.xcworkspace/xcshareddata/swiftpm/Package.resolved` file—as opposed to incorrectly using one from a `*.xcodeproj/**/Package.resolved`.

## WIP / Draft

> [!IMPORTANT]
> The changes in this PR and bash script have not been really tested. In practice I've written the logic mostly blind (i.e. without trying to run it on any repo to test it), and I'm only opening the PR as Draft so soon so I can get feedback on the code and the logic.

We should definitively take some extra time to test those changes on various repos in various setups:
 - lib repo with `Package.swift`, repo with `.xcworkspace` at repo root but `.xcodeproj` in subdir, repo with both `.xcworkspace` and `.xcodeproj` files at repo root, repo with multiple `.xcworkspace` and/or `.xcodeproj` files and multiple `Package.resolved` files, repos with no `Package.resolved` file at all…;
 - calling the utility with explicit `--workspace`/`--scheme`/`--project`/`--use-spm` parameters, with only `--workspace` and letting it guess the scheme, with no parameter, …

## Compatibility / Breaking Change

Note that this is technically a breaking change for the `install_swiftpm_dependencies` utility, since it previously accepted 2 optional extra arguments (full custom path to `Package.resolved`, and build type), while the new implementation doesn't accept those optional extra arguments anymore.

This is intentional, as:
 - It would be complex (and for little benefit) to keep backwards compatibility while also making it consistent with the new flags
 - But more importantly, I think those optional arguments were not working as expected. In particular, providing a custom path for the `Package.resolved` as the first argument made this path used for the computation of the cache key during cache restoration and save… but that custom file was not the one used by `swift package resolve` or `xcodebuild -resolvePackageDependencies` during dependency resolution, so that would lead to inconsistencies and odd behaviors if used

Tbh though, I'm not even sure any of our repos currently calling `install_swiftpm_dependencies` ever passed extra parameters to it though, so those were probably never ever used in practice anyway?

## Suggestion for adopting repos

Repos like [PocketCasts-iOS were having issues with that utility](https://github.com/Automattic/pocket-casts-ios/issues/1990) because it was inconsistently using either `podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` when calling `xcodebuild -resolvePackageDependencies`(without a `-workspace`, thus making it fallback to the `.xcodeproj`) during resolution while the cache was relying on `podcasts.xcworkspace/xcshareddata/swiftpm/Package.resolved` for the cache (or when developers resolved dependencies via Xcode and commited that file), and those two different `Package.resolved` files were not in sync.

I'd suggest for repos in such situations to:
 - Delete the `*.xcodeproj/xcshareddata/swiftpm/Package.resolved` file and remove it from git, so that only the one in the `*.xcworkspace` is kept around
 - Update the calls to `install_swiftpm_dependencies` in the `.buildkite/**` scripts to provide the `--workspace` (and `--scheme`) explicitly

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
