### PR TITLE
Release 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,30 +48,36 @@ _None._
 
 _None._
 
+## 3.5.1
+
+### Bug Fixes
+
+ - Fix an issue in `annotate_test_failures` when test cases had apostrophes in their name. [#106]
+
 ## 3.5.0
 
 ### New Features
 
-- Introduce `merge_junit_reports` script [#103]
+- Introduce `merge_junit_reports` script. [#103]
 
 ## 3.4.2
 
 ### Bug Fixes
 
-- Fix `hash_directory` helper, and make it portable (Mac+Linux) [#95]
+- Fix `hash_directory` helper, and make it portable (Mac+Linux). [#95]
 
 ## 3.4.1
 
 ### Bug Fixes
 
-- Fix for the unbound variable error seen on `run_swiftlint` [#92]
+- Fix for the unbound variable error seen on `run_swiftlint`. [#92]
 
 ## 3.4.0
 
 ### Internal Changes
 
-- Restrict the possible `run_swiftlint` command arguments to "--strict" and "--lenient" [#90]
-- Update `swiftlint_version` RegExp to check for top-level node [#89]
+- Restrict the possible `run_swiftlint` command arguments to "--strict" and "--lenient". [#90]
+- Update `swiftlint_version` RegExp to check for top-level node. [#89]
 
 ## 3.3.0
 
@@ -81,13 +87,13 @@ _None._
 
 ### Internal Changes
 
-- Fixed Ruby, RuboCop and RSpec versions on CI [#88]
+- Fixed Ruby, RuboCop and RSpec versions on CI. [#88]
 
 ## 3.2.2
 
 ### Bug Fixes
 
- - Fix crash in recent update of the `publish_pod` implementation — 2nd attempt [#85]
+ - Fix crash in recent update of the `publish_pod` implementation — 2nd attempt. [#85]
 
 ## 3.2.1
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.5.0:
+      - automattic/a8c-ci-toolkit#3.5.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.5.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.5.1`.
 
 ## Configuration
 


### PR DESCRIPTION
Release 3.5.1 to ship #106

# What's Next

Once this is merged:

 - Create a new GitHub release named `3.5.1`, with the following description, and publish it:
```
### Bug Fixes

 - Fix an issue in `annotate_test_failures` when test cases had apostrophes in their name. [#106]
```
 - Update the references to `a8c-ci-toolkit` plugin in client repos to use `3.5.1` (cc @wzieba I'll let you update it in WCAndroid at least)