### PR TITLE
[Tooling] Add `github_commit_status` to all pipeline jobs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # For convenience with the many install_swiftpm_dependencies steps, we declare agents and env for macOS in the root, then specialize the fewer remaining steps
 agents:
   queue: mac
@@ -7,11 +10,17 @@ env:
 steps:
   - label: ":sleuth_or_spy: Lint"
     command: make lint
+    notify:
+      - github_commit_status:
+          context: Lint
     agents:
       queue: default
 
   - label: ":microscope: Test"
     command: make test
+    notify:
+      - github_commit_status:
+          context: Test
     agents:
       queue: default
 
@@ -22,6 +31,9 @@ steps:
     retry:
       manual:
         permit_on_passed: true
+    notify:
+      - github_commit_status:
+          context: Danger - PR Check
     agents:
       queue: linter
 
@@ -29,27 +41,54 @@ steps:
     steps:
       - label: ":swift: Standalone Swift Package - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_package_automatic.sh
+        notify:
+          - github_commit_status:
+              context: Standalone Swift Package - Autodetect
 
       - label: ":swift: Standalone Swift Package - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_package_explicit.sh
+        notify:
+          - github_commit_status:
+              context: Standalone Swift Package - Explicit
 
       - label: ":xcode: Xcode Project - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_automatic.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Project - Autodetect
 
       - label: ":xcode: Xcode Project - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_explicit.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Project - Explicit
 
       - label: ":xcode: Xcode Project - No Package.resolved"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_no_package.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Project - No Package.resolved
 
       - label: ":xcode: Xcode Workspace - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_automatic.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Workspace - Autodetect
 
       - label: ":xcode: Xcode Workspace - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_explicit.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Workspace - Explicit
 
       - label: ":xcode: Xcode Workspace and Project - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_automatic.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Workspace and Project - Autodetect
 
       - label: ":xcode: Xcode Workspace and Project - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_explicit.sh
+        notify:
+          - github_commit_status:
+              context: Xcode Workspace and Project - Explicit

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -43,52 +43,52 @@ steps:
         command: tests/install_swiftpm_dependencies/test_scripts/test_package_automatic.sh
         notify:
           - github_commit_status:
-              context: Standalone Swift Package - Autodetect
+              context: "install_swiftpm_dependencies Tests: Standalone Swift Package - Autodetect"
 
       - label: ":swift: Standalone Swift Package - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_package_explicit.sh
         notify:
           - github_commit_status:
-              context: Standalone Swift Package - Explicit
+              context: "install_swiftpm_dependencies Tests: Standalone Swift Package - Explicit"
 
       - label: ":xcode: Xcode Project - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_automatic.sh
         notify:
           - github_commit_status:
-              context: Xcode Project - Autodetect
+              context: "install_swiftpm_dependencies Tests: Xcode Project - Autodetect"
 
       - label: ":xcode: Xcode Project - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_explicit.sh
         notify:
           - github_commit_status:
-              context: Xcode Project - Explicit
+              context: "install_swiftpm_dependencies Tests: Xcode Project - Explicit"
 
       - label: ":xcode: Xcode Project - No Package.resolved"
         command: tests/install_swiftpm_dependencies/test_scripts/test_project_no_package.sh
         notify:
           - github_commit_status:
-              context: Xcode Project - No Package.resolved
+              context: "install_swiftpm_dependencies Tests: Xcode Project - No Package.resolved"
 
       - label: ":xcode: Xcode Workspace - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_automatic.sh
         notify:
           - github_commit_status:
-              context: Xcode Workspace - Autodetect
+              context: "install_swiftpm_dependencies Tests: Xcode Workspace - Autodetect"
 
       - label: ":xcode: Xcode Workspace - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_explicit.sh
         notify:
           - github_commit_status:
-              context: Xcode Workspace - Explicit
+              context: "install_swiftpm_dependencies Tests: Xcode Workspace - Explicit"
 
       - label: ":xcode: Xcode Workspace and Project - Autodetect"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_automatic.sh
         notify:
           - github_commit_status:
-              context: Xcode Workspace and Project - Autodetect
+              context: "install_swiftpm_dependencies Tests: Xcode Workspace and Project - Autodetect"
 
       - label: ":xcode: Xcode Workspace and Project - Explicit"
         command: tests/install_swiftpm_dependencies/test_scripts/test_workspace_and_project_explicit.sh
         notify:
           - github_commit_status:
-              context: Xcode Workspace and Project - Explicit
+              context: "install_swiftpm_dependencies Tests: Xcode Workspace and Project - Explicit"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,17 +5,17 @@ env:
   IMAGE_ID: xcode-15.4
 
 steps:
-  - label: "🕵️ Lint"
+  - label: ":sleuth_or_spy: Lint"
     command: make lint
     agents:
       queue: default
 
-  - label: "🔬 Test"
+  - label: ":microscope: Test"
     command: make test
     agents:
       queue: default
 
-  - label: "☢️ Danger - PR Check"
+  - label: ":radioactive_sign: Danger - PR Check"
     command: danger
     key: danger
     if: build.pull_request.id != null


### PR DESCRIPTION
The goal of this and related PRs is to have a reference implementation for paaHJt-78h-p2: pipeline status updates with explicit names, with Buildkite automatic status disabled.

This PR depends on https://github.com/Automattic/buildkite-ci/pull/516

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
