### PR TITLE
Check for `$BUILDKITE_PULL_REQUEST = false`  when uploading sarif file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+Check for $BUILDKITE_PULL_REQUEST = false when uploading sarif file [#116]
 
 ### Internal Changes
 

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -31,7 +31,7 @@ sarif_base64_temp_file=$(mktemp)
 
 gzip -c "$sarif_file" | base64 > "$sarif_base64_temp_file"
 
-if [[ -n $BUILDKITE_PULL_REQUEST ]]; then
+if [[ $BUILDKITE_PULL_REQUEST != "false" ]]; then
   json=$(jq -n \
     --arg commit_sha "$BUILDKITE_COMMIT" \
     --arg pr_number "$BUILDKITE_PULL_REQUEST" \

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -31,7 +31,7 @@ sarif_base64_temp_file=$(mktemp)
 
 gzip -c "$sarif_file" | base64 > "$sarif_base64_temp_file"
 
-if [[ $BUILDKITE_PULL_REQUEST != "false" ]]; then
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
   json=$(jq -n \
     --arg commit_sha "$BUILDKITE_COMMIT" \
     --arg pr_number "$BUILDKITE_PULL_REQUEST" \

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -51,6 +51,8 @@ elif [[ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
      "ref": ("refs/heads/$branch"),
      "sarif": $sarif
    }')
+else
+  exit 0
 fi
 
 sarif_json_temp_file=$(mktemp)


### PR DESCRIPTION
If build is not associated with a pull request, Buildkite puts value `false` for `$BUILDKITE_PULL_REQUEST`
Initially, I thought it just doesn't create such variable.

Proof can be found here: https://buildkite.com/automattic/pocket-casts-android/builds/8308#0191e617-a1e2-4ae6-a7bb-4ef3dda51370

Because of this bug, after merge to trunk in Pocket Casts we can see:
```
{
  | [2024-09-12T12:07:17Z]   "message": "ref 'refs/pull/false/head' not found in this repository",
  | [2024-09-12T12:07:17Z]   "documentation_url": "https://docs.github.com/rest/code-scanning/code-scanning#upload-an-analysis-as-sarif-data",
  | [2024-09-12T12:07:17Z]   "status": "404"
  | [2024-09-12T12:07:17Z] 
}
```

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
