### PR TITLE
Fix passing main branch name when sending sarif file

### DIFF
--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -48,7 +48,7 @@ elif [[ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
     --rawfile sarif "$sarif_base64_temp_file" \
     '{
      "commit_sha": $commit_sha,
-     "ref": ("refs/heads/$branch"),
+     "ref": ("refs/heads/"+$branch),
      "sarif": $sarif
    }')
 else


### PR DESCRIPTION
On a main branch. Before this fix, we'd have `"message": "ref 'refs/heads/$branch' not found in this repository",`


---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
