### PR TITLE
Comment with dependency diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add a script for commenting dependencies diff on PRs in Android projects [#120]
 
 ### Bug Fixes
 

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -132,28 +132,32 @@ comment_body_file=$(mktemp)
 echo "$comment_body" > "$comment_body_file"
 
 # Use jq with the temporary file for payload
-json_payload_file=$(mktemp)
-jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}' > "$json_payload_file"
+#jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}' > "$json_payload_file"
 
-# Clean up temporary files
-rm "$comment_body_file"
+json=$(jq -c --null-input \
+  --rawfile body "$comment_body_file" \
+  '{
+    body: $body
+   }
+  '
+)
+
+json_payload_file=$(mktemp)
+echo "$json" > "$json_payload_file"
 
 if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
     echo "Update the existing comment: $existing_comment_id"
     github_api "$issues_endpoint/comments/$existing_comment_id" \
         --fail-with-body -X PATCH \
         -H "Content-Type: application/json" \
-        -d @"$json_payload_file"
+        --data-binary @"$json_payload_file"
 elif [[ -n "$arg_pr_comment" ]]; then
     echo "Post a new comment"
     github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
         --fail-with-body -X POST \
         -H "Content-Type: application/json" \
-        -d @"$json_payload_file"
+        --data-binary @"$json_payload_file"
 else
     # No comment body was given in CLI, so no new comment to post
     echo "No new comment to post"
 fi
-
-# Clean up json payload file
-rm "$json_payload_file"

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -126,7 +126,16 @@ $comment_body_id
 $arg_pr_comment
 EOF
 )
-json_payload=$(jq -c --null-input --arg body "$comment_body" '{body: $body}')
+
+# Write the comment body to a temporary file to fix possible "Argument list too long" error
+comment_body_file=$(mktemp)
+echo "$comment_body" > "$comment_body_file"
+
+# Use jq with the temporary file
+json_payload=$(jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}')
+
+# Clean up temporary files
+rm "$comment_body_file"
 
 if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
     echo "Update the existing comment: $existing_comment_id"

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -131,8 +131,9 @@ EOF
 comment_body_file=$(mktemp)
 echo "$comment_body" > "$comment_body_file"
 
-# Use jq with the temporary file
-json_payload=$(jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}')
+# Use jq with the temporary file for payload
+json_payload_file=$(mktemp)
+jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}' > "$json_payload_file"
 
 # Clean up temporary files
 rm "$comment_body_file"
@@ -142,14 +143,17 @@ if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
     github_api "$issues_endpoint/comments/$existing_comment_id" \
         --fail-with-body -X PATCH \
         -H "Content-Type: application/json" \
-        -d "${json_payload}"
+        -d @"$json_payload_file"
 elif [[ -n "$arg_pr_comment" ]]; then
     echo "Post a new comment"
     github_api "$issues_endpoint/${BUILDKITE_PULL_REQUEST}/comments" \
         --fail-with-body -X POST \
         -H "Content-Type: application/json" \
-        -d "${json_payload}"
+        -d @"$json_payload_file"
 else
     # No comment body was given in CLI, so no new comment to post
     echo "No new comment to post"
 fi
+
+# Clean up json payload file
+rm "$json_payload_file"

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -131,16 +131,11 @@ EOF
 comment_body_file=$(mktemp)
 echo "$comment_body" > "$comment_body_file"
 
-json=$(jq -c --null-input \
-  --rawfile body "$comment_body_file" \
-  '{
-    body: $body
-   }
-  '
-)
-
 json_payload_file=$(mktemp)
-echo "$json" > "$json_payload_file"
+jq -c --null-input \
+  --rawfile body "$comment_body_file" \
+  '{ body: $body }' \
+  > "$json_payload_file"
 
 if [[ -n "$existing_comment_id" && "$opt_if_exist" == "update" ]]; then
     echo "Update the existing comment: $existing_comment_id"

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -131,9 +131,6 @@ EOF
 comment_body_file=$(mktemp)
 echo "$comment_body" > "$comment_body_file"
 
-# Use jq with the temporary file for payload
-#jq -c --null-input --arg body "$(cat "$comment_body_file")" '{body: $body}' > "$json_payload_file"
-
 json=$(jq -c --null-input \
   --rawfile body "$comment_body_file" \
   '{

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -158,8 +158,8 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
     current_size=$(wc -c < "$COMMENT_FILE")
 
     # Calculate if there's enough space for the content and header
-    if (( current_size + ${#header} + ${#content} > github_comment_max_size - ${#warning_message} )); then
-      printf "%s\n" "$warning_message" > $COMMENT_FILE
+    if (( current_size + ${#header} + ${#content} > github_comment_max_size - ${#header} - ${#warning_message})); then
+      printf "\n%s\n%s\n" "$header" "$warning_message" > $COMMENT_FILE
       return
     fi
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -119,18 +119,24 @@ EOF
 
 if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   echo "--> Commenting result to GitHub"
-  COMMENT_BODY=""
+
+  # Create or clear the comment body file
+  COMMENT_FILE="$DIFF_DEPENDENCIES_FOLDER/comment_body.txt"
+  true > $COMMENT_FILE  # 'true' used to clear the file as a no-op
+
   if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-    COMMENT_BODY+="$(generate_project_dependencies_comment_body)"
+    generate_project_dependencies_comment_body >> $COMMENT_FILE
   fi
+
   if [ -s $DIFF_BUILD_ENV_FILE ]; then
-    COMMENT_BODY+="$(generate_build_dependencies_comment_body)"
+    generate_build_dependencies_comment_body >> $COMMENT_FILE
   fi
+
+  # Run the fastlane command and pass the comment body from the file
   bundle exec fastlane run comment_on_pr \
-    github_token:$GITHUB_TOKEN \
+    github_token:"$GITHUB_TOKEN" \
     project:"$OWNER/$REPO" \
-    pr_number:$PR_NUMBER \
-    body:"$COMMENT_BODY" \
+    pr_number:"$PR_NUMBER" \
+    body:"$(cat $COMMENT_FILE)" \
     reuse_identifier:"dependency-diff"
 fi
-

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -132,11 +132,13 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
     generate_build_dependencies_comment_body >> $COMMENT_FILE
   fi
 
+  COMMENT_BODY=$(<"$COMMENT_FILE")
+
   # Run the fastlane command and pass the comment body from the file
   bundle exec fastlane run comment_on_pr \
     github_token:"$GITHUB_TOKEN" \
     project:"$OWNER/$REPO" \
     pr_number:"$PR_NUMBER" \
-    body:"$(cat $COMMENT_FILE)" \
+    body:"$COMMENT_BODY" \
     reuse_identifier:"dependency-diff"
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -132,13 +132,7 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
     generate_build_dependencies_comment_body >> $COMMENT_FILE
   fi
 
-  COMMENT_BODY=""
+  COMMENT_BODY=$(<"$COMMENT_FILE")
 
-  # Run the fastlane command and pass the comment body from the file
-  bundle exec fastlane run comment_on_pr \
-    github_token:"$GITHUB_TOKEN" \
-    project:"$OWNER/$REPO" \
-    pr_number:"$PR_NUMBER" \
-    body:"$COMMENT_BODY" \
-    reuse_identifier:"dependency-diff"
+  comment_on_pr --id "dependency-diff" --if-exist update "$COMMENT_BODY"
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -81,9 +81,9 @@ The following changes in project dependencies were detected
 
 <details><summary>expand</summary>
 
-```diff
+\`\`\`diff
 $(cat "$DIFF_DEPENDENCIES_FILE")
-```
+\`\`\`
 
 </details>
 
@@ -99,16 +99,14 @@ The following changes in the build environment were detected:
 
 <details><summary>expand</summary>
 
-```diff
+\`\`\`diff
 $(cat "$DIFF_BUILD_ENV_FILE")
-```
+\`\`\`
 
 </details>
 
 EOF
 }
-
-
 
 if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   echo "--> Commenting result to GitHub"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -35,7 +35,7 @@ echo "--> Base branch is $baseBranch"
 # state of the codebase.
 git merge "origin/$baseBranch" --no-edit
 
-if (git diff --name-status "origin/$baseBranch" | grep ".gradle*" --quiet) then
+if (git diff --name-status "origin/$baseBranch" | grep ".gradle*|.toml" --quiet) then
     echo ".gradle files have been changed. Looking for caused dependency changes"
   else
     echo ".gradle files haven't been changed. There is no need to run the diff"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -1,0 +1,70 @@
+#!/bin/bash -eu
+
+DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
+BASE_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_dependencies.txt"
+HEAD_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_dependencies.txt"
+DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
+CONFIGURATION="releaseRuntimeClasspath"
+DEPENDENCY_TREE_VERSION="1.2.1"
+
+REPO_HANDLE="bloom/DayOne-Android"
+
+PR_NUMBER=$BUILDKITE_PULL_REQUEST
+PR_URL="https://api.github.com/repos/$REPO_HANDLE/pulls/$PR_NUMBER"
+
+git config --global user.email "mobile@automattic.com"
+git config --global user.name "Dependency Tree Diff Tool"
+
+echo "--> Starting the check"
+echo "--> Fetching the base branch from $PR_URL"
+githubResponse="$(curl "$PR_URL" -H "Authorization: token $GITHUB_TOKEN")"
+baseBranch=$(echo "$githubResponse" | tr '\r\n' ' ' | jq '.base.ref' | tr -d '"')
+echo "--> Base branch is $baseBranch"
+
+# The merge helps catch any discrepancies caused by outdated dependency tree, since the branch
+# could be behind base branch even if the PR itself doesn't introduce direct changes. Merging
+# base branch in advance provides a more robust verification process by simulating the post-merge
+# state of the codebase.
+git merge "origin/$baseBranch" --no-edit
+
+if (git diff --name-status "origin/$baseBranch" | grep ".gradle" --quiet) then
+    echo ".gradle files have been changed. Looking for caused dependency changes"
+  else
+    echo ".gradle files haven't been changed. There is no need to run the diff"
+    ./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${PR_NUMBER}" -DGITHUB_OAUTH2TOKEN="$GITHUB_TOKEN"
+    exit 0
+fi
+
+mkdir -p "$DIFF_DEPENDENCIES_FOLDER"
+
+echo "--> Generating dependencies to the file $HEAD_BRANCH_DEPENDENCIES_FILE"
+./gradlew :app:dependencies --configuration $CONFIGURATION >$HEAD_BRANCH_DEPENDENCIES_FILE
+
+echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
+git checkout "$baseBranch"
+./gradlew :app:dependencies --configuration $CONFIGURATION >$BASE_BRANCH_DEPENDENCIES_FILE
+git checkout "-"
+
+echo "--> Downloading dependency-tree-diff.jar"
+# https://github.com/JakeWharton/dependency-tree-diff
+curl -v -L "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$DEPENDENCY_TREE_VERSION/dependency-tree-diff.jar" -o dependency-tree-diff.jar
+sha=$(sha1sum dependency-tree-diff.jar | cut -d' ' -f1)
+if [[ $sha != "39c50f22cd4211a3e52afec43120b7fdf90f9890" ]]; then
+  echo "dependency-tree-diff.jar file has unexpected sha1"
+  exit 1
+fi
+chmod +x dependency-tree-diff.jar
+
+echo "--> Running dependency-tree-diff.jar"
+./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
+
+if [ -s $DIFF_DEPENDENCIES_FILE ]; then
+  echo "There are changes in dependencies of the project"
+  cat "$DIFF_DEPENDENCIES_FILE"
+else
+  echo "There are no changes in dependencies of the project"
+  rm "$DIFF_DEPENDENCIES_FILE"
+fi
+
+echo "--> Commenting result to GitHub"
+./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${PR_NUMBER##*/}" -DGITHUB_OAUTH2TOKEN="$GITHUB_TOKEN" --info

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -40,7 +40,6 @@ if (git diff --name-status "origin/$baseBranch" | grep ".gradle*|.toml" --quiet)
     echo ".gradle files have been changed. Looking for caused dependency changes"
   else
     echo ".gradle files haven't been changed. There is no need to run the diff"
-    ./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${PR_NUMBER}" -DGITHUB_OAUTH2TOKEN="$GITHUB_TOKEN"
     exit 0
 fi
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -132,7 +132,5 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
     generate_build_dependencies_comment_body >> $COMMENT_FILE
   fi
 
-  COMMENT_BODY=$(<"$COMMENT_FILE")
-
-  comment_on_pr --id "dependency-diff" --if-exist update "$COMMENT_BODY"
+  comment_on_pr --id "dependency-diff" --if-exist update "$COMMENT_FILE"
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -151,14 +151,14 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   append_content() {
     local header="$1"
     local content="$2"
-    local max_size=65536
-    local warning_message="Content exceeds $max_size characters. Check Buildkite artifacts for details."
+    local github_comment_max_size=65536
+    local warning_message="Content exceeds $github_comment_max_size characters. [Navigate to Buildkite build artifacts](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}) to see details."
 
     local current_size
     current_size=$(wc -c < "$COMMENT_FILE")
 
     # Calculate if there's enough space for the content and header
-    if (( current_size + ${#header} + ${#content} > max_size - ${#warning_message} )); then
+    if (( current_size + ${#header} + ${#content} > github_comment_max_size - ${#warning_message} )); then
       printf "%s\n" "$warning_message" > $COMMENT_FILE
       return
     fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -2,12 +2,13 @@
 
 set -euo pipefail
 
-CONFIGURATION="${1:-}"
-OWNER="${2:-}"
-REPO="${3:-}"
+MODULE="${1:-}"
+CONFIGURATION="${2:-}"
+OWNER="${3:-}"
+REPO="${4:-}"
 
-if [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
-  echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <CONFIGURATION> <OWNER> <REPO>"
+if [ -z "$MODULE" ] [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <MODULE> <CONFIGURATION> <OWNER> <REPO>"
   exit 1
 fi
 
@@ -46,11 +47,11 @@ fi
 mkdir -p "$DIFF_DEPENDENCIES_FOLDER"
 
 echo "--> Generating dependencies to the file $HEAD_BRANCH_DEPENDENCIES_FILE"
-./gradlew :app:dependencies --configuration "$CONFIGURATION" >$HEAD_BRANCH_DEPENDENCIES_FILE
+./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$HEAD_BRANCH_DEPENDENCIES_FILE
 
 echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
 git checkout "$baseBranch"
-./gradlew :app:dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
+./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 git checkout "-"
 
 echo "--> Downloading dependency-tree-diff.jar"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -35,9 +35,9 @@ echo "--> Base branch is $baseBranch"
 
 git merge "origin/$baseBranch" --no-edit
 
-if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet) then
+if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet); then
     echo ".gradle files have been changed. Looking for caused dependency changes"
-  else
+else
     echo ".gradle files haven't been changed. There is no need to run the diff"
     exit 0
 fi
@@ -114,10 +114,10 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   echo "--> Commenting result to GitHub"
   COMMENT_BODY=""
   if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-    COMMENT_BODY += $(generate_project_dependencies_comment_body)
+    COMMENT_BODY+="$(generate_project_dependencies_comment_body)"
   fi
   if [ -s $DIFF_BUILD_ENV_FILE ]; then
-    COMMENT_BODY += $(generate_build_dependencies_comment_body)
+    COMMENT_BODY+="$(generate_build_dependencies_comment_body)"
   fi
   bundle exec fastlane run comment_on_pr \
     github_token:$GITHUB_TOKEN \

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -123,8 +123,10 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   append_content() {
     local content="$1"
     local github_pr_comment_max_size=65536
+    local current_file_size
+    current_file_size=$(wc -c < "$COMMENT_FILE")
 
-    if [ "${#content}" -gt $github_pr_comment_max_size ]; then
+    if (( current_file_size + ${#content} > github_pr_comment_max_size )); then
       echo "Content exceeds $github_pr_comment_max_size characters. Navigate to Buildkite build artifacts to see details." >> $COMMENT_FILE
     else
       echo "$content" >> $COMMENT_FILE
@@ -147,3 +149,4 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
 else
   comment_on_pr --id "dependency-diff" --if-exist delete
 fi
+

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -71,30 +71,49 @@ chmod +x dependency-tree-diff.jar
 echo "--> Running dependency-tree-diff.jar"
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 
-COMMENT_BODY=""
+generate_project_dependencies_comment_body() {
+  cat <<EOF
+## Dependency Changes
 
-# Add the dependency diff to the comment
-if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-  echo "There are changes in dependencies of the project"
-  COMMENT_BODY+="## Dependency Changes\n"
-  COMMENT_BODY+="The following changes in project dependencies were detected:\n"
-  COMMENT_BODY+="\`\`\`diff\n$(cat "$DIFF_DEPENDENCIES_FILE")\n\`\`\`\n"
-fi
+The following changes in project dependencies were detected
 
-# Generate diff for build environment
-echo "--> Generating build environment diff"
-diff $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE || true
+<details><summary>expand</summary>
 
-# Add the build environment diff to the comment
-if [ -s $DIFF_BUILD_ENV_FILE ]; then
-  echo "There are changes in the build environment dependencies"
-  COMMENT_BODY+="## Build Environment Changes\n"
-  COMMENT_BODY+="The following changes in the build environment were detected:\n"
-  COMMENT_BODY+="\`\`\`diff\n$(cat "$DIFF_BUILD_ENV_FILE")\n\`\`\`\n"
-fi
+```diff
+$(cat "$DIFF_DEPENDENCIES_FILE")
+```
+
+</details>
+
+EOF
+}
+
+generate_build_dependencies_comment_body() {
+  cat <<EOF
+
+## Build Environment Changes
+
+The following changes in the build environment were detected:
+
+<details><summary>expand</summary>
+
+```diff
+$(cat "$DIFF_BUILD_ENV_FILE")
+```
+
+</details>
+
+EOF
+}
+
+
 
 if [ -n "$COMMENT_BODY" ]; then
   echo "--> Commenting result to GitHub"
+  COMMENT_BODY=$(generate_project_dependencies_comment_body)
+  if [ -s $DIFF_BUILD_ENV_FILE ]; then
+    COMMENT_BODY += $(generate_build_dependencies_comment_body)
+  fi
   bundle exec fastlane run comment_on_pr \
     github_token:$GITHUB_TOKEN \
     project:"$OWNER/$REPO" \
@@ -102,3 +121,4 @@ if [ -n "$COMMENT_BODY" ]; then
     body:"$COMMENT_BODY" \
     reuse_identifier:"dependency-diff"
 fi
+

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -1,16 +1,24 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -euo pipefail
+
+CONFIGURATION="${1:-}"
+OWNER="${2:-}"
+REPO="${3:-}"
+
+if [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+  echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <CONFIGURATION> <OWNER> <REPO>"
+  exit 1
+fi
 
 DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
 BASE_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_dependencies.txt"
 HEAD_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_dependencies.txt"
 DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
-CONFIGURATION="releaseRuntimeClasspath"
 DEPENDENCY_TREE_VERSION="1.2.1"
 
-REPO_HANDLE="bloom/DayOne-Android"
-
 PR_NUMBER=$BUILDKITE_PULL_REQUEST
-PR_URL="https://api.github.com/repos/$REPO_HANDLE/pulls/$PR_NUMBER"
+PR_URL="https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER"
 
 git config --global user.email "mobile@automattic.com"
 git config --global user.name "Dependency Tree Diff Tool"
@@ -38,11 +46,11 @@ fi
 mkdir -p "$DIFF_DEPENDENCIES_FOLDER"
 
 echo "--> Generating dependencies to the file $HEAD_BRANCH_DEPENDENCIES_FILE"
-./gradlew :app:dependencies --configuration $CONFIGURATION >$HEAD_BRANCH_DEPENDENCIES_FILE
+./gradlew :app:dependencies --configuration "$CONFIGURATION" >$HEAD_BRANCH_DEPENDENCIES_FILE
 
 echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
 git checkout "$baseBranch"
-./gradlew :app:dependencies --configuration $CONFIGURATION >$BASE_BRANCH_DEPENDENCIES_FILE
+./gradlew :app:dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 git checkout "-"
 
 echo "--> Downloading dependency-tree-diff.jar"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -132,7 +132,7 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
     generate_build_dependencies_comment_body >> $COMMENT_FILE
   fi
 
-  COMMENT_BODY=$(<"$COMMENT_FILE")
+  COMMENT_BODY=""
 
   # Run the fastlane command and pass the comment body from the file
   bundle exec fastlane run comment_on_pr \

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -4,13 +4,14 @@ set -euo pipefail
 
 MODULE="${1:-}"
 CONFIGURATION="${2:-}"
-OWNER="${3:-}"
-REPO="${4:-}"
 
-if [ -z "$MODULE" ] || [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
-  echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <MODULE> <CONFIGURATION> <OWNER> <REPO>"
+if [ -z "$MODULE" ] || [ -z "$CONFIGURATION" ]; then
+  echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <MODULE> <CONFIGURATION>"
   exit 1
 fi
+
+OWNER=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO}")")
+REPO=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 
 DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
 BASE_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_dependencies.txt"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -72,7 +72,7 @@ if [ -s $DIFF_DEPENDENCIES_FILE ]; then
   COMMENT_BODY=$(printf "This PR causes following diff of project dependencies:\n\`\`\`diff\n%s\n\`\`\`" "$(cat "$DIFF_DEPENDENCIES_FILE")")
 
   echo "--> Commenting result to GitHub"
-  bundle exec fastlane comment_on_pr \
+  bundle exec fastlane run comment_on_pr \
     github_token:$GITHUB_TOKEN \
     project:"$OWNER/$REPO" \
     pr_number:$PR_NUMBER \

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -51,6 +51,8 @@ echo "--> Generating build environment dependencies for the head branch"
 ./gradlew buildEnvironment >$HEAD_BRANCH_BUILD_ENV_FILE
 
 echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
+git status
+git diff
 git checkout "$baseBranch"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -43,9 +43,6 @@ if [ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]; then
   exit 2
 fi
 
-OWNER=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO}")")
-REPO=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
-
 DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
 BASE_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_dependencies.txt"
 HEAD_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_dependencies.txt"
@@ -55,16 +52,11 @@ DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
 DIFF_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_build_env.txt"
 DEPENDENCY_TREE_VERSION="1.2.1"
 
-PR_NUMBER=$BUILDKITE_PULL_REQUEST
-PR_URL="https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER"
-
 git config --global user.email "mobile@automattic.com"
 git config --global user.name "Dependency Tree Diff Tool"
 
 echo "--> Starting the check"
-echo "--> Fetching the base branch from $PR_URL"
-githubResponse="$(curl "$PR_URL" -H "Authorization: token $GITHUB_TOKEN")"
-baseBranch=$(echo "$githubResponse" | tr '\r\n' ' ' | jq '.base.ref' | tr -d '"')
+baseBranch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
 echo "--> Base branch is $baseBranch"
 
 git merge "origin/$baseBranch" --no-edit

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -82,7 +82,6 @@ echo "--> Running dependency-tree-diff.jar"
 
 generate_project_dependencies_comment_body() {
   cat <<EOF
-## Project dependencies changes
 
 The following changes in project dependencies were detected (configuration "$CONFIGURATION"):
 
@@ -100,9 +99,6 @@ EOF
 
 generate_build_dependencies_comment_body() {
   cat <<EOF
-
-
-## Build environment changes
 
 The following changes in the build classpath were detected:
 
@@ -124,13 +120,30 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   COMMENT_FILE="$DIFF_DEPENDENCIES_FOLDER/comment_body.txt"
   true > $COMMENT_FILE  # 'true' used to clear the file as a no-op
 
+  append_content() {
+    local content="$1"
+    local github_pr_comment_max_size=65536
+
+    if [ "${#content}" -gt $github_pr_comment_max_size ]; then
+      echo "Content exceeds $github_pr_comment_max_size characters. Navigate to Buildkite build artifacts to see details." >> $COMMENT_FILE
+    else
+      echo "$content" >> $COMMENT_FILE
+    fi
+  }
+
   if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-    generate_project_dependencies_comment_body >> $COMMENT_FILE
+    printf "## Project dependencies changes\n\n" >> $COMMENT_FILE
+    content=$(generate_project_dependencies_comment_body)
+    append_content "$content"
   fi
 
   if [ -s $DIFF_BUILD_ENV_FILE ]; then
-    generate_build_dependencies_comment_body >> $COMMENT_FILE
+    printf "## Build environment changes\n\n" >> $COMMENT_FILE
+    content=$(generate_build_dependencies_comment_body)
+    append_content "$content"
   fi
 
   comment_on_pr --id "dependency-diff" --if-exist update "$COMMENT_FILE"
+else
+  comment_on_pr --id "dependency-diff" --if-exist delete
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -51,8 +51,13 @@ echo "--> Generating build environment dependencies for the head branch"
 ./gradlew buildEnvironment >$HEAD_BRANCH_BUILD_ENV_FILE
 
 echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
-git status
-git diff
+
+if ! git diff --quiet; then
+  echo "Changes detected. Stashing and continuing with the script"
+  git diff
+  git stash
+fi
+
 git checkout "$baseBranch"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -50,7 +50,9 @@ BASE_BRANCH_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_build_env.txt"
 HEAD_BRANCH_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_build_env.txt"
 DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
 DIFF_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_build_env.txt"
+
 DEPENDENCY_TREE_VERSION="1.2.1"
+DEPENDENCY_TREE_CHECKSUM="39c50f22cd4211a3e52afec43120b7fdf90f9890"
 
 git config --global user.email "mobile@automattic.com"
 git config --global user.name "Dependency Tree Diff Tool"
@@ -95,7 +97,7 @@ git checkout "-"
 echo "--> Downloading dependency-tree-diff.jar"
 curl -v -L "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$DEPENDENCY_TREE_VERSION/dependency-tree-diff.jar" -o dependency-tree-diff.jar
 sha=$(sha1sum dependency-tree-diff.jar | cut -d' ' -f1)
-if [[ $sha != "39c50f22cd4211a3e52afec43120b7fdf90f9890" ]]; then
+if [[ $sha != "$DEPENDENCY_TREE_CHECKSUM" ]]; then
   echo "dependency-tree-diff.jar file has unexpected sha1"
   exit 1
 fi
@@ -175,4 +177,3 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
 else
   comment_on_pr --id "dependency-diff" --if-exist delete
 fi
-

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -7,7 +7,7 @@ CONFIGURATION="${2:-}"
 OWNER="${3:-}"
 REPO="${4:-}"
 
-if [ -z "$MODULE" ] [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+if [ -z "$MODULE" ] || [ -z "$CONFIGURATION" ] || [ -z "$OWNER" ] || [ -z "$REPO" ]; then
   echo "Not enough arguments provided. Usage: ./comment_with_dependency_diff <MODULE> <CONFIGURATION> <OWNER> <REPO>"
   exit 1
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -15,7 +15,10 @@ fi
 DIFF_DEPENDENCIES_FOLDER="./build/reports/diff"
 BASE_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_dependencies.txt"
 HEAD_BRANCH_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_dependencies.txt"
+BASE_BRANCH_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/base_branch_build_env.txt"
+HEAD_BRANCH_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/head_branch_build_env.txt"
 DIFF_DEPENDENCIES_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_dependencies.txt"
+DIFF_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/diff_build_env.txt"
 DEPENDENCY_TREE_VERSION="1.2.1"
 
 PR_NUMBER=$BUILDKITE_PULL_REQUEST
@@ -30,10 +33,6 @@ githubResponse="$(curl "$PR_URL" -H "Authorization: token $GITHUB_TOKEN")"
 baseBranch=$(echo "$githubResponse" | tr '\r\n' ' ' | jq '.base.ref' | tr -d '"')
 echo "--> Base branch is $baseBranch"
 
-# The merge helps catch any discrepancies caused by outdated dependency tree, since the branch
-# could be behind base branch even if the PR itself doesn't introduce direct changes. Merging
-# base branch in advance provides a more robust verification process by simulating the post-merge
-# state of the codebase.
 git merge "origin/$baseBranch" --no-edit
 
 if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet) then
@@ -48,13 +47,19 @@ mkdir -p "$DIFF_DEPENDENCIES_FOLDER"
 echo "--> Generating dependencies to the file $HEAD_BRANCH_DEPENDENCIES_FILE"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$HEAD_BRANCH_DEPENDENCIES_FILE
 
+echo "--> Generating build environment dependencies for the head branch"
+./gradlew buildEnvironment >$HEAD_BRANCH_BUILD_ENV_FILE
+
 echo "--> Generating dependencies to the file $BASE_BRANCH_DEPENDENCIES_FILE"
 git checkout "$baseBranch"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
+
+echo "--> Generating build environment dependencies for the base branch"
+./gradlew buildEnvironment >$BASE_BRANCH_BUILD_ENV_FILE
+
 git checkout "-"
 
 echo "--> Downloading dependency-tree-diff.jar"
-# https://github.com/JakeWharton/dependency-tree-diff
 curl -v -L "https://github.com/JakeWharton/dependency-tree-diff/releases/download/$DEPENDENCY_TREE_VERSION/dependency-tree-diff.jar" -o dependency-tree-diff.jar
 sha=$(sha1sum dependency-tree-diff.jar | cut -d' ' -f1)
 if [[ $sha != "39c50f22cd4211a3e52afec43120b7fdf90f9890" ]]; then
@@ -66,11 +71,29 @@ chmod +x dependency-tree-diff.jar
 echo "--> Running dependency-tree-diff.jar"
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 
+COMMENT_BODY=""
+
+# Add the dependency diff to the comment
 if [ -s $DIFF_DEPENDENCIES_FILE ]; then
   echo "There are changes in dependencies of the project"
+  COMMENT_BODY+="## Dependency Changes\n"
+  COMMENT_BODY+="The following changes in project dependencies were detected:\n"
+  COMMENT_BODY+="\`\`\`diff\n$(cat "$DIFF_DEPENDENCIES_FILE")\n\`\`\`\n"
+fi
 
-  COMMENT_BODY=$(printf "This PR causes following diff of project dependencies:\n\`\`\`diff\n%s\n\`\`\`" "$(cat "$DIFF_DEPENDENCIES_FILE")")
+# Generate diff for build environment
+echo "--> Generating build environment diff"
+diff $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE || true
 
+# Add the build environment diff to the comment
+if [ -s $DIFF_BUILD_ENV_FILE ]; then
+  echo "There are changes in the build environment dependencies"
+  COMMENT_BODY+="## Build Environment Changes\n"
+  COMMENT_BODY+="The following changes in the build environment were detected:\n"
+  COMMENT_BODY+="\`\`\`diff\n$(cat "$DIFF_BUILD_ENV_FILE")\n\`\`\`\n"
+fi
+
+if [ -n "$COMMENT_BODY" ]; then
   echo "--> Commenting result to GitHub"
   bundle exec fastlane run comment_on_pr \
     github_token:$GITHUB_TOKEN \

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -38,6 +38,11 @@ if [ -z "$MODULE" ] || [ -z "$CONFIGURATION" ]; then
   exit 1
 fi
 
+if [ "${BUILDKITE_PULL_REQUEST:-false}" == "false" ]; then
+  echo "This script should only be called on pull requests. Be sure to set \`if: build.pull_request.id != null\` on the step invoking it in your Buildkite pipeline"
+  exit 2
+fi
+
 OWNER=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO}")")
 REPO=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -75,9 +75,9 @@ echo "--> Running dependency-tree-diff.jar"
 
 generate_project_dependencies_comment_body() {
   cat <<EOF
-## Dependency Changes
+## Project dependencies changes
 
-The following changes in project dependencies were detected
+The following changes in project dependencies were detected (configuration "$CONFIGURATION"):
 
 <details><summary>expand</summary>
 
@@ -87,15 +87,17 @@ $(cat "$DIFF_DEPENDENCIES_FILE")
 
 </details>
 
+
 EOF
 }
 
 generate_build_dependencies_comment_body() {
   cat <<EOF
 
-## Build Environment Changes
 
-The following changes in the build environment were detected:
+## Build environment changes
+
+The following changes in the build classpath were detected:
 
 <details><summary>expand</summary>
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -35,7 +35,7 @@ echo "--> Base branch is $baseBranch"
 # state of the codebase.
 git merge "origin/$baseBranch" --no-edit
 
-if (git diff --name-status "origin/$baseBranch" | grep ".gradle" --quiet) then
+if (git diff --name-status "origin/$baseBranch" | grep ".gradle*" --quiet) then
     echo ".gradle files have been changed. Looking for caused dependency changes"
   else
     echo ".gradle files haven't been changed. There is no need to run the diff"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -83,7 +83,7 @@ echo "--> Running dependency-tree-diff.jar"
 generate_project_dependencies_comment_body() {
   cat <<EOF
 
-The following changes in project dependencies were detected (configuration \`"$CONFIGURATION"\`):
+The following changes in project dependencies were detected (configuration \`$CONFIGURATION\`):
 
 <details><summary>expand</summary>
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -68,11 +68,14 @@ echo "--> Running dependency-tree-diff.jar"
 
 if [ -s $DIFF_DEPENDENCIES_FILE ]; then
   echo "There are changes in dependencies of the project"
-  cat "$DIFF_DEPENDENCIES_FILE"
-else
-  echo "There are no changes in dependencies of the project"
-  rm "$DIFF_DEPENDENCIES_FILE"
-fi
 
-echo "--> Commenting result to GitHub"
-./gradlew dependencyTreeDiffCommentToGitHub -DGITHUB_PULLREQUESTID="${PR_NUMBER##*/}" -DGITHUB_OAUTH2TOKEN="$GITHUB_TOKEN" --info
+  COMMENT_BODY=$(printf "This PR causes following diff of project dependencies:\n\`\`\`diff\n%s\n\`\`\`" "$(cat "$DIFF_DEPENDENCIES_FILE")")
+
+  echo "--> Commenting result to GitHub"
+  bundle exec fastlane comment_on_pr \
+    github_token:$GITHUB_TOKEN \
+    project:"$OWNER/$REPO" \
+    pr_number:$PR_NUMBER \
+    body:"$COMMENT_BODY" \
+    reuse_identifier: "dependency-diff"
+fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -149,28 +149,30 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   true > $COMMENT_FILE  # 'true' used to clear the file as a no-op
 
   append_content() {
-    local content="$1"
-    local github_pr_comment_max_size=65536
-    local current_file_size
-    current_file_size=$(wc -c < "$COMMENT_FILE")
+    local header="$1"
+    local content="$2"
+    local max_size=65536
+    local warning_message="Content exceeds $max_size characters. Check Buildkite artifacts for details."
 
-    if (( current_file_size + ${#content} > github_pr_comment_max_size )); then
-      echo "Content exceeds $github_pr_comment_max_size characters. Navigate to Buildkite build artifacts to see details." >> $COMMENT_FILE
-    else
-      echo "$content" >> $COMMENT_FILE
+    local current_size
+    current_size=$(wc -c < "$COMMENT_FILE")
+
+    # Calculate if there's enough space for the content and header
+    if (( current_size + ${#header} + ${#content} > max_size - ${#warning_message} )); then
+      printf "%s\n" "$warning_message" > $COMMENT_FILE
+      return
     fi
+
+    printf "\n%s\n" "$header" >> $COMMENT_FILE
+    printf "%s\n" "$content" >> $COMMENT_FILE
   }
 
-  if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-    printf "\n## Project dependencies changes\n\n" >> $COMMENT_FILE
-    content=$(generate_project_dependencies_comment_body)
-    append_content "$content"
+  if [ -s "$DIFF_DEPENDENCIES_FILE" ]; then
+    append_content "## Project dependencies changes" "$(generate_project_dependencies_comment_body)"
   fi
 
-  if [ -s $DIFF_BUILD_ENV_FILE ]; then
-    printf "\n## Build environment changes\n\n" >> $COMMENT_FILE
-    content=$(generate_build_dependencies_comment_body)
-    append_content "$content"
+  if [ -s "$DIFF_BUILD_ENV_FILE" ]; then
+    append_content "## Build environment changes" "$(generate_build_dependencies_comment_body)"
   fi
 
   comment_on_pr --id "dependency-diff" --if-exist update "$COMMENT_FILE"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -83,7 +83,7 @@ echo "--> Running dependency-tree-diff.jar"
 generate_project_dependencies_comment_body() {
   cat <<EOF
 
-The following changes in project dependencies were detected (configuration "$CONFIGURATION"):
+The following changes in project dependencies were detected (configuration \`"$CONFIGURATION"\`):
 
 <details><summary>expand</summary>
 
@@ -134,13 +134,13 @@ if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   }
 
   if [ -s $DIFF_DEPENDENCIES_FILE ]; then
-    printf "## Project dependencies changes\n\n" >> $COMMENT_FILE
+    printf "\n## Project dependencies changes\n\n" >> $COMMENT_FILE
     content=$(generate_project_dependencies_comment_body)
     append_content "$content"
   fi
 
   if [ -s $DIFF_BUILD_ENV_FILE ]; then
-    printf "## Build environment changes\n\n" >> $COMMENT_FILE
+    printf "\n## Build environment changes\n\n" >> $COMMENT_FILE
     content=$(generate_build_dependencies_comment_body)
     append_content "$content"
   fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -36,7 +36,7 @@ echo "--> Base branch is $baseBranch"
 # state of the codebase.
 git merge "origin/$baseBranch" --no-edit
 
-if (git diff --name-status "origin/$baseBranch" | grep ".gradle*|.toml" --quiet) then
+if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet) then
     echo ".gradle files have been changed. Looking for caused dependency changes"
   else
     echo ".gradle files haven't been changed. There is no need to run the diff"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -1,5 +1,33 @@
 #!/bin/bash
 
+# This script is used in a Buildkite CI pipeline to analyze and comment on dependency changes in a
+# GitHub pull request (PR). It compares the Gradle project dependencies and build environment between the
+# base branch and the head branch to identify changes caused by updates to Gradle files.
+#
+# Usage:
+#    ./comment_with_dependency_diff <MODULE> <CONFIGURATION>
+#
+# Parameters:
+#    <MODULE>        : The Gradle module whose dependencies will be checked.
+#    <CONFIGURATION> : The Gradle configuration to inspect for dependencies (e.g., "runtimeClasspath").
+#
+# Steps:
+# 1. The script fetches the base branch of the PR and merges it into the head branch.
+# 2. It generates the dependency and build environment reports for both the base and head branches.
+# 3. The script compares these reports to detect any changes in the project's dependencies.
+# 4. If changes are found, the script creates a comment on the GitHub PR with the results.
+# 5. If no changes are detected, the script exits without posting any comment.
+#
+# Notes:
+# - The GitHub token must be set via the environment variable `GITHUB_TOKEN` to authenticate API requests.
+# - The comment on the PR will include a summary of changes and a detailed list in expandable sections.
+# - A jar file `dependency-tree-diff.jar` is downloaded and executed to perform the dependency diff.
+#
+# Example:
+#    ./comment_with_dependency_diff app release
+#
+# This will analyze the `app` module with the `release` configuration and post the result to the PR.
+
 set -euo pipefail
 
 MODULE="${1:-}"
@@ -37,9 +65,9 @@ echo "--> Base branch is $baseBranch"
 git merge "origin/$baseBranch" --no-edit
 
 if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet); then
-    echo ".gradle files have been changed. Looking for caused dependency changes"
+    echo "Gradle files have been changed. Looking for caused dependency changes"
 else
-    echo ".gradle files haven't been changed. There is no need to run the diff"
+    echo "Gradle files haven't been changed. There is no need to run the diff"
     exit 0
 fi
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -77,5 +77,5 @@ if [ -s $DIFF_DEPENDENCIES_FILE ]; then
     project:"$OWNER/$REPO" \
     pr_number:$PR_NUMBER \
     body:"$COMMENT_BODY" \
-    reuse_identifier: "dependency-diff"
+    reuse_identifier:"dependency-diff"
 fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -71,6 +71,8 @@ chmod +x dependency-tree-diff.jar
 echo "--> Running dependency-tree-diff.jar"
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 
+./dependency-tree-diff.jar $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE
+
 generate_project_dependencies_comment_body() {
   cat <<EOF
 ## Dependency Changes
@@ -108,9 +110,12 @@ EOF
 
 
 
-if [ -n "$COMMENT_BODY" ]; then
+if [ -n "$DIFF_DEPENDENCIES_FILE" ] || [ -n "$DIFF_BUILD_ENV_FILE" ]; then
   echo "--> Commenting result to GitHub"
-  COMMENT_BODY=$(generate_project_dependencies_comment_body)
+  COMMENT_BODY=""
+  if [ -s $DIFF_DEPENDENCIES_FILE ]; then
+    COMMENT_BODY += $(generate_project_dependencies_comment_body)
+  fi
   if [ -s $DIFF_BUILD_ENV_FILE ]; then
     COMMENT_BODY += $(generate_build_dependencies_comment_body)
   fi

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -56,12 +56,12 @@ git config --global user.email "mobile@automattic.com"
 git config --global user.name "Dependency Tree Diff Tool"
 
 echo "--> Starting the check"
-baseBranch=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
-echo "--> Base branch is $baseBranch"
+BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
+echo "--> Base branch is $BASE_BRANCH"
 
-git merge "origin/$baseBranch" --no-edit
+git merge "origin/$BASE_BRANCH" --no-edit
 
-if (git diff --name-status "origin/$baseBranch" | grep -E "\.gradle(\.kts)?|\.toml" --quiet); then
+if (git diff --name-status "origin/$BASE_BRANCH" | grep -E "\.gradle(\.kts)?|\.toml" --quiet); then
     echo "Gradle files have been changed. Looking for caused dependency changes"
 else
     echo "Gradle files haven't been changed. There is no need to run the diff"
@@ -84,7 +84,7 @@ if ! git diff --quiet; then
   git stash
 fi
 
-git checkout "$baseBranch"
+git checkout "$BASE_BRANCH"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 
 echo "--> Generating build environment dependencies for the base branch"


### PR DESCRIPTION
### Description

This PR introduces `comment_with_dependency_diff` script that is aiming to help Android product teams to better understand what changes to the dependency tree a PR might introduce.

We use similar scripts in WooCommerce and Day One projects. I want to extend support to other projects and share the implementation between them for easier maintenance.

Additionally, this PR introduces some improvements to the script:
- comment on PR without using Gradle (so our Android apps can remove another, not really needed dependency from their codebase)
- print build environment changes as well (previously, the script was only printing runtime dependencies changes)

To see the result, please see:
- Pocket Casts: https://github.com/Automattic/pocket-casts-android/pull/2857
- Matticspace Mobile (for the case of a large diff): https://github.com/Automattic/Matticspace-Mobile/pull/67

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
