### PR TITLE
Don't require passing owner and repo names to `upload_sarif_to_github`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Don't require passing owner and repo names to `upload_sarif_to_github` [#121]
 
 ### Internal Changes
 

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -3,11 +3,11 @@
 set -euo pipefail
 
 sarif_file="${1:-}"
-owner="${2:-}"
-repo="${3:-}"
+owner=$(basename "$(dirname "${BUILDKITE_PULL_REQUEST_REPO}")")
+repo=$(basename "${BUILDKITE_PULL_REQUEST_REPO%.git}")
 
-if [ -z "$sarif_file" ] || [ -z "$owner" ] || [ -z "$repo" ]; then
-  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report> <gh owner> <gh repo>"
+if [ -z "$sarif_file" ]; then
+  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report>"
   exit 1
 fi
 


### PR DESCRIPTION
We can extract this data from Buildkite

Proof that it works: https://github.com/Automattic/pocket-casts-android/pull/2866 (specifically: https://buildkite.com/automattic/pocket-casts-android/builds/8387#0191fa68-20ce-4458-a78c-2f1e899372d7/179-248)


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
