### PR TITLE
[Dependency Cache] Dependency Cache on CI per Project [without GRADLE_RO_DEP_CACHE]

### DIFF
--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
 
 CACHE_KEY=$1
-CACHE_FILE=${2:-} # Optional - defaults to empty if not provided, and the uncompressed cache size not measured (or reported).
 
 bytes_to_mb() {
 	local bytes=$1
@@ -36,12 +35,9 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 	fi
 
-	COMPRESSED_CACHE_SIZE=$(wc -c < "$CACHE_KEY")
+	CACHE_SIZE=$(wc -c < "$CACHE_KEY")
 	echo "	Decompressing"
 	tar -xf "$CACHE_KEY"
-	if [ -n "$CACHE_FILE" ]; then
-		UNCOMPRESSED_CACHE_SIZE=$(du -sb "$CACHE_FILE" | awk '{print $1}')
-	fi
 
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
@@ -49,10 +45,7 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 	duration=$SECONDS
 	echo "Cache entry successfully restored"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
-	echo "	Cache Size (Compressed): $(bytes_to_mb "$COMPRESSED_CACHE_SIZE") MB"
-	if [ -n "$CACHE_FILE" ]; then
-		echo "	Cache Size (Uncompressed): $(bytes_to_mb "$UNCOMPRESSED_CACHE_SIZE") MB"
-	fi
+	echo "	Cache Size: $(bytes_to_mb "$CACHE_SIZE") MB"
 else
 	echo "No cache entry found for '$CACHE_KEY'"
 fi

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -1,6 +1,7 @@
 #!/bin/bash -eu
 
 CACHE_KEY=$1
+CACHE_FILE=${2:-} # Optional - defaults to empty if not provided, and the uncompressed cache size not measured (or reported).
 
 bytes_to_mb() {
 	local bytes=$1
@@ -38,6 +39,9 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 	COMPRESSED_CACHE_SIZE=$(wc -c < "$CACHE_KEY")
 	echo "	Decompressing"
 	tar -xf "$CACHE_KEY"
+	if [ -n "$CACHE_FILE" ]; then
+		UNCOMPRESSED_CACHE_SIZE=$(du -sb "$CACHE_FILE" | awk '{print $1}')
+	fi
 
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
@@ -46,6 +50,9 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 	echo "Cache entry successfully restored"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
 	echo "	Cache Size (Compressed): $(bytes_to_mb "$COMPRESSED_CACHE_SIZE") MB"
+	if [ -n "$CACHE_FILE" ]; then
+		echo "	Cache Size (Uncompressed): $(bytes_to_mb "$UNCOMPRESSED_CACHE_SIZE") MB"
+	fi
 else
 	echo "No cache entry found for '$CACHE_KEY'"
 fi

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -16,6 +16,7 @@ fi
 echo "Using $S3_BUCKET_NAME as cache bucket"
 
 if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1; then
+	SECONDS=0
 	echo "Restoring cache entry $CACHE_KEY"
 
 	echo "	Downloading"
@@ -34,6 +35,10 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
+
+	duration=$SECONDS
+	echo "Cache entry successfully restored"
+	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
 else
 	echo "No cache entry found for '$CACHE_KEY'"
 fi

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -2,6 +2,11 @@
 
 CACHE_KEY=$1
 
+bytes_to_mb() {
+	local bytes=$1
+	printf "%.2f" "$(awk "BEGIN {print $bytes / (1024 * 1024)}")"
+}
+
 S3_BUCKET_NAME=${CACHE_BUCKET_NAME-}
 if [ -z "$S3_BUCKET_NAME" ]; then
 	if [ -z "$BUILDKITE_PLUGIN_A8C_CI_TOOLKIT_BUCKET" ]; then
@@ -30,6 +35,7 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 	fi
 
+	COMPRESSED_CACHE_SIZE=$(wc -c < "$CACHE_KEY")
 	echo "	Decompressing"
 	tar -xf "$CACHE_KEY"
 
@@ -39,6 +45,7 @@ if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/nu
 	duration=$SECONDS
 	echo "Cache entry successfully restored"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
+	echo "	Cache Size (Compressed): $(bytes_to_mb "$COMPRESSED_CACHE_SIZE") MB"
 else
 	echo "No cache entry found for '$CACHE_KEY'"
 fi

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -6,10 +6,11 @@ GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
 echo "Restoring Gradle dependency cache..."
 
 DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_RO_DEP_CACHE")
+DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_RO_DEP_CACHE")
 
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
 pushd "$DEP_CACHE_BASE_FOLDER"
-restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY"
+restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY" "$DEP_CACHE_FOLDER_NAME"
 popd
 
 echo "---"

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"
 
 echo "Restoring Gradle dependency cache..."
 

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -9,11 +9,10 @@ echo "Restoring Gradle dependency cache..."
 GRADLE_DEP_CACHE="$GRADLE_HOME/dependency-cache"
 
 DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_DEP_CACHE")
-DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_DEP_CACHE")
 
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
 pushd "$DEP_CACHE_BASE_FOLDER"
-restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY" "$DEP_CACHE_FOLDER_NAME"
+restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY"
 
 if [ -d "$DEP_CACHE_FOLDER_NAME/modules-2/" ]; then
 	echo "Placing Gradle dependency cache..."

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."
 

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -5,12 +5,22 @@ GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
 
 echo "Restoring Gradle dependency cache..."
 
-DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_RO_DEP_CACHE")
-DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_RO_DEP_CACHE")
+# The directory is shared with `bin/save_gradle_dependency_cache`
+GRADLE_DEP_CACHE="$GRADLE_HOME/dependency-cache"
+
+DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_DEP_CACHE")
+DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_DEP_CACHE")
 
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
 pushd "$DEP_CACHE_BASE_FOLDER"
 restore_cache "$GRADLE_DEPENDENCY_CACHE_KEY" "$DEP_CACHE_FOLDER_NAME"
+
+if [ -d "$DEP_CACHE_FOLDER_NAME/modules-2/" ]; then
+	echo "Placing Gradle dependency cache..."
+	mv "$DEP_CACHE_FOLDER_NAME/modules-2/"* caches/modules-2/
+	rm -r "$DEP_CACHE_FOLDER_NAME"
+fi
+
 popd
 
 echo "---"

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -45,6 +45,7 @@ if [[ "$SHOULD_FORCE" == '--force' ]]; then
 fi
 
 if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1; then
+	SECONDS=0
 	echo "No existing cache entry for $CACHE_KEY – storing in cache"
 
 	echo "	Compressing"
@@ -73,6 +74,10 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
+
+	duration=$SECONDS
+	echo "Cache entry successfully saved"
+	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
 else
 	echo "This file is already cached – skipping upload"
 fi

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -3,6 +3,11 @@
 CACHE_FILE=$1
 CACHE_KEY=$2
 
+bytes_to_mb() {
+	local bytes=$1
+	printf "%.2f" "$(awk "BEGIN {print $bytes / (1024 * 1024)}")"
+}
+
 if [ -z "$CACHE_FILE" ]; then
 	echo "You must pass the file or directory you want to be cached"
 	exit 1
@@ -48,6 +53,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	SECONDS=0
 	echo "No existing cache entry for $CACHE_KEY – storing in cache"
 
+	UNCOMPRESSED_CACHE_SIZE=$(du -sb "$CACHE_FILE" | awk '{print $1}')
 	echo "	Compressing"
 	TAR_CONFIG=${4-}
 	if [[ "$TAR_CONFIG" == '--use_relative_path_in_tar' ]]; then
@@ -60,6 +66,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	else
 		tar -czf "$CACHE_KEY" "$CACHE_FILE"
 	fi
+	COMPRESSED_CACHE_SIZE=$(wc -c < "$CACHE_KEY")
 
 	echo "	Uploading"
 	# If the bucket has transfer acceleration enabled, use it!
@@ -78,6 +85,8 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	duration=$SECONDS
 	echo "Cache entry successfully saved"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
+	echo "	Cache Size (Uncompressed): $(bytes_to_mb "$UNCOMPRESSED_CACHE_SIZE") MB"
+	echo "	Cache Size (Compressed): $(bytes_to_mb "$COMPRESSED_CACHE_SIZE") MB"
 else
 	echo "This file is already cached – skipping upload"
 fi

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -53,7 +53,6 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	SECONDS=0
 	echo "No existing cache entry for $CACHE_KEY – storing in cache"
 
-	UNCOMPRESSED_CACHE_SIZE=$(du -sb "$CACHE_FILE" | awk '{print $1}')
 	echo "	Compressing"
 	TAR_CONFIG=${4-}
 	if [[ "$TAR_CONFIG" == '--use_relative_path_in_tar' ]]; then
@@ -66,7 +65,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	else
 		tar -czf "$CACHE_KEY" "$CACHE_FILE"
 	fi
-	COMPRESSED_CACHE_SIZE=$(wc -c < "$CACHE_KEY")
+	CACHE_SIZE=$(wc -c < "$CACHE_KEY")
 
 	echo "	Uploading"
 	# If the bucket has transfer acceleration enabled, use it!
@@ -85,8 +84,7 @@ if ! aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/
 	duration=$SECONDS
 	echo "Cache entry successfully saved"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
-	echo "	Cache Size (Uncompressed): $(bytes_to_mb "$UNCOMPRESSED_CACHE_SIZE") MB"
-	echo "	Cache Size (Compressed): $(bytes_to_mb "$COMPRESSED_CACHE_SIZE") MB"
+	echo "	Cache Size: $(bytes_to_mb "$CACHE_SIZE") MB"
 else
 	echo "This file is already cached – skipping upload"
 fi

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"
 
 echo "Saving Gradle dependency cache..."
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="GRADLE_DEPENDENCY_CACHE"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
 
 echo "Saving Gradle dependency cache..."
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -5,16 +5,19 @@ GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE"
 
 echo "Saving Gradle dependency cache..."
 
-mkdir -p "$GRADLE_RO_DEP_CACHE"
+# The directory is shared with `bin/restore_gradle_dependency_cache`
+GRADLE_DEP_CACHE="$GRADLE_HOME/dependency-cache"
+
+mkdir -p "$GRADLE_DEP_CACHE"
 
 # https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:cache_copy
 # Gradle suggests removing the `*.lock` files and the `gc.properties` file before saving cache
-cp -r ~/.gradle/caches/modules-2 "$GRADLE_RO_DEP_CACHE" \
-    && find "$GRADLE_RO_DEP_CACHE" -name "*.lock" -type f -delete \
-    && find "$GRADLE_RO_DEP_CACHE" -name "gc.properties" -type f -delete
+cp -r ~/.gradle/caches/modules-2 "$GRADLE_DEP_CACHE" \
+    && find "$GRADLE_DEP_CACHE" -name "*.lock" -type f -delete \
+    && find "$GRADLE_DEP_CACHE" -name "gc.properties" -type f -delete
 
-DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_RO_DEP_CACHE")
-DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_RO_DEP_CACHE")
+DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_DEP_CACHE")
+DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_DEP_CACHE")
 
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
 pushd "$DEP_CACHE_BASE_FOLDER"


### PR DESCRIPTION
Project Thread: paaHJt-7CE-p2
Related: #134 + [buildkite-ci#570](https://github.com/Automattic/buildkite-ci/pull/570)
(Softly) Depends On:
- [WCAndroid#13288](https://github.com/woocommerce/woocommerce-android/pull/13288)
- [FluxC#3125](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3125)
- [ADC#39](https://github.com/Automattic/android-dependency-catalog/pull/39)

---

### Description

This change:

1. Adds a project prefix (`BUILDKITE_PIPELINE_SLUG`) to the existing gradle dependency cache key to enable dependency cache per project. (3b051ba9e5b84e8e2ecfc9cb55047631ef596d83)
2. Enhances [save_cache](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/86bc60f6cf0bb53a7616296dadcfd43aa72c53e9/bin/save_cache) and [restore_cache](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/86bc60f6cf0bb53a7616296dadcfd43aa72c53e9/bin/restore_cache) logging by:
    1. Echoing how long it takes to save/restore the cache. (f777f0207fb0f2f4432a94012ad60fd20a7bedee)
    2. Echoing the (un)compressed cache size during save/restore. (938009b30e9f7afb6230d1650f21489f1cb93976 + fb579e83d220d7d8e2062550963741a00c5fea9d)
3. Replaces the read-only [GRADLE_RO_DEP_CACHE](https://docs.gradle.org/current/userguide/dependency_caching.html#sec:shared-readonly-cache) dependency cache mechanism (using the `$GRADLE_HOME/read-only-dependency-cache` directory), with the more basic [GRADLE_DEP_CACHE](https://docs.gradle.org/current/userguide/dependency_caching.html#sec:cache-copy) dependency cache mechanism (using `$GRADLE_HOME/dependency-cache` directory), for save/restore. (61b1d9d39a46b585ac5cadf67d9d7223fb878ff0)
4. Adds a version suffix (`V2`) to the existing gradle dependency cache key to differentiate between the two, the previous `GRADLE_RO_DEP_CACHE` and the new `GRADLE_DEP_CACHE` dependency cache mechanisms. This was purely done for testing purposes, but I think it might be wise for us to keep this versioning system in place, just in case we update the mechanism again in the future and want to effectively test, then utilize that new change. PS: I am very open to feedback on that. (94d9f7a3829cd21d9f31b5ee962178c26606c71e)

> [!NOTE]
> Enhancing the [save_cache](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/86bc60f6cf0bb53a7616296dadcfd43aa72c53e9/bin/save_cache) and [restore_cache](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/86bc60f6cf0bb53a7616296dadcfd43aa72c53e9/bin/restore_cache) scripts (2.) will positively affect all clients of these scripts, mainly improve things by logging some more information. But, do think if there is going to be a case when these changes might negatively effect some or all those other clients (`I couldn't).

---

### Testing Instructions

This `GRADLE_DEP_CACHE` version of `a8c-ci-toolkit` was thoroughly tested via the below test-only PRs, via the help of the `android-staging` agents (see [buildkite-ci#570](https://github.com/Automattic/buildkite-ci/pull/570)):

- [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/13170)
- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/21550)

To help you assessing that this change is safe use to use and will not cause any trouble for any project, try and follow the below:

- [WCAndroid](https://github.com/woocommerce/woocommerce-android)
  - Latest [save related](https://buildkite.com/automattic/woocommerce-android/builds/26484) build:
    - Prior to all the tasks starting, verify that there [NO](https://buildkite.com/automattic/woocommerce-android/builds/26484#0194503a-4127-47b0-afc3-647aa787a6da/181-182) restore cache triggered (no `local pre-command hook` has run).
    - When all the dependency download tasks finish, [save cache](https://buildkite.com/automattic/woocommerce-android/builds/26484#0194503a-4127-47b0-afc3-647aa787a6da/451-452) get triggered:
      - Using the correct [project prefix and version suffix](https://buildkite.com/automattic/woocommerce-android/builds/26484#0194503a-4127-47b0-afc3-647aa787a6da/451-456).
      - Logging both, [the time it took for the cache to be saved](https://buildkite.com/automattic/woocommerce-android/builds/26484#0194503a-4127-47b0-afc3-647aa787a6da/451-462) and [the size of the saved cache](https://buildkite.com/automattic/woocommerce-android/builds/26484#0194503a-4127-47b0-afc3-647aa787a6da/451-463).
  - Latest [restore related](https://buildkite.com/automattic/woocommerce-android/builds/26485) build:
    - Prior to the `assemble` task starting, [restore cache](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/189-190) gets triggered:
      - Using the correct [project prefix and version suffix](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/189-193).
      - Logging both, [the time it took for the cache to be restored](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/189-198) and [the size of the restored cache](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/189-199).
      - Finally, that the restored cache is [placed correctly](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/189-201).
    - As the `assemble` tasks starts, verify that there is [NO](https://buildkite.com/automattic/woocommerce-android/builds/26485#0194504e-1c03-41fd-9ed2-a20f6bc350bc/238-248) mention of a `read-only dependency cache` cache.
- [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android)
  - Latest [save related](https://buildkite.com/automattic/wordpress-android/builds/20820) build:
    - Prior to all the tasks starting, verify that there [NO](https://buildkite.com/automattic/wordpress-android/builds/20820#0194503a-caf5-438c-9a8f-f55eaf562078/187-188) restore cache triggered (no `local pre-command hook` has run).
    - When all the dependency download tasks finish, [save cache](https://buildkite.com/automattic/wordpress-android/builds/20820#0194503a-caf5-438c-9a8f-f55eaf562078/528-529) get triggered:
      - Using the correct [project prefix and version suffix](https://buildkite.com/automattic/wordpress-android/builds/20820#0194503a-caf5-438c-9a8f-f55eaf562078/528-533).
      - Logging both, [the time it took for the cache to be saved](https://buildkite.com/automattic/wordpress-android/builds/20820#0194503a-caf5-438c-9a8f-f55eaf562078/528-539) and [the size of the saved cache](https://buildkite.com/automattic/wordpress-android/builds/20820#0194503a-caf5-438c-9a8f-f55eaf562078/528-540).
  - Latest [restore related](https://buildkite.com/automattic/wordpress-android/builds/20821) build:
    - Prior to the `assemble` task starting, [restore cache](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/196-197) gets triggered:
      - Using the correct [project prefix and version suffix](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/196-200).
      - Logging both, [the time it took for the cache to be restored](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/196-205) and [the size of the restored cache](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/196-206).
      - Finally, that the restored cache is [placed correctly](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/196-208).
    - As the `assemble` tasks starts, verify that there is [NO](https://buildkite.com/automattic/wordpress-android/builds/20821#01945058-1739-4ada-8449-76ed42053121/246-262) mention of a `read-only dependency cache` cache.

> [!NOTE]
> The `GRADLE_RO_DEP_CACHE` version of `a8c-ci-toolkit` was also tested via the below test-only PRs:
> - [WCAndroid](https://github.com/woocommerce/woocommerce-android/pull/13122)
> - [JP/WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/21540)

---

### Merge Instructions

- [x] Wait for [buildkite-ci#570](https://github.com/Automattic/buildkite-ci/pull/570) to be reviewed, approved, deployed and merged.
- [x] Wait for [WCAndroid#13288](https://github.com/woocommerce/woocommerce-android/pull/13288) to be reviewed, approved and merged. (`restore cache hook removed`)
- [x] Wait for [FluxC#3125](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3125) to be reviewed, approved and merged. (`restore cache hook removed`)
- [x] Wait for [ADC#39](https://github.com/Automattic/android-dependency-catalog/pull/39) to be reviewed, approved and merged. (`save cache trigger removed`)
- [x] Remove `do not merge` label.
- [x] Merge this PR.
- [x] Close #98 and #134 test-only PRs.

> [!NOTE]
> These [WCAndroid#13288](https://github.com/woocommerce/woocommerce-android/pull/13288) + [FluxC#3125](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3125) + [ADC#39](https://github.com/Automattic/android-dependency-catalog/pull/39) PRs are not necessarily needed prior to merging this change, but it is better to clean things up and avoid any confusion with relation to having save/restore working on client/libraries projects, while it is actually not (and shouldn't be as of yet).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.