### PR TITLE
Only attempt to install pods when linting strings if CP is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- `lint_localized_strings_format` will bypass CocoaPods if a `Podfile.lock` is not found [#136]
 
 ### Bug Fixes
 

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -13,7 +13,11 @@ install_gems
 # The strings generation also picks up files from our first party libraries,
 # some of which are installed via CocoaPods
 echo "--- :cocoapods: Setting up Pods"
-install_cocoapods
+if [[ -f Podfile.lock ]]; then
+  install_cocoapods
+else
+  echo "CocoaPods setup not detected. Skipping CocoaPods installation..."
+fi
 
 echo "--- :sleuth_or_spy: Lint Apple Localized Strings Format"
 # A next step improvement is to move the logs management within the release


### PR DESCRIPTION
As we start removing CocoaPods from some of our projects, we can no longer assume pods exist locally to install.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/23951 which prompted this change.

Example in action: https://buildkite.com/automattic/wordpress-ios/builds/25292#01943fbf-a124-4d9e-910a-b1cb8871bfcb

![image](https://github.com/user-attachments/assets/8912bba9-d0e1-453f-b9a4-580d43b13365)



---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
