### PR TITLE
[Dependency Cache] Fix Dependency Cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 3.9.0
+
+### New Features
+
+- `Dependency Cache` Dependency Cache on CI per Project `without GRADLE_RO_DEP_CACHE` by @ParaskP7 in [#135]
+
 ## 3.8.0
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _None._
 
 ### Bug Fixes
 
+- `Dependency Cache`: Fix Dependency Cache [#138]
 - `run_swiftlint`: Error gracefully when `swiftlint_version` is missing in the `.swiftlint.yml` file [#139]
 
 ### Internal Changes
@@ -52,7 +53,7 @@ _None._
 
 ### New Features
 
-- `Dependency Cache` Dependency Cache on CI per Project `without GRADLE_RO_DEP_CACHE` by @ParaskP7 in [#135]
+- `Dependency Cache`: Dependency Cache on CI per Project `[without GRADLE_RO_DEP_CACHE]` [#135]
 
 ## 3.8.0
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.8.0:
+      - automattic/a8c-ci-toolkit#3.9.0:
           bucket: a8c-ci-cache # optional
 ```
 

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -9,6 +9,7 @@ echo "Restoring Gradle dependency cache..."
 GRADLE_DEP_CACHE="$GRADLE_HOME/dependency-cache"
 
 DEP_CACHE_BASE_FOLDER=$(dirname "$GRADLE_DEP_CACHE")
+DEP_CACHE_FOLDER_NAME=$(basename "$GRADLE_DEP_CACHE")
 
 # `save_cache` & `restore_cache` scripts only work if they are called from the same directory
 pushd "$DEP_CACHE_BASE_FOLDER"


### PR DESCRIPTION
Related: #135

### Description

As part of #135 and this last 1dda7bd51d20fbb82d5435dc2cbee3b08f5b5153 commit I incorrectly removed the `DEP_CACHE_FOLDER_NAME` variable. Without this variable set, placing Gradle dependency cache is not working as expected due to the fact that this `DEP_CACHE_FOLDER_NAME` variable is now unbound. And this makes this whole dependency cache solution not working at all.

---

### Testing Instructions

Base on this [WCAndroid##13303](https://github.com/woocommerce/woocommerce-android/pull/13303) PR and this [test commit](https://github.com/woocommerce/woocommerce-android/pull/13303/commits/49d771a9cf4f11e7efdf7dd0641e2b529bf39f07), looking at its corresponding [build](https://buildkite.com/automattic/woocommerce-android/builds/26598):
1. Notice that during the [cache restoration](https://buildkite.com/automattic/woocommerce-android/builds/26598#01946985-7315-47ec-bea7-01814e8a7755/189-190) process on a specific job (ie. `Mobile App`) the [cache is being placed](https://buildkite.com/automattic/woocommerce-android/builds/26598#01946985-7315-47ec-bea7-01814e8a7755/189-200) as expected.
2. Looking at the [network activity](https://scans.gradle.com/s/aqheikr2epk5u/performance/network-activity) of a specific job (ie. `Mobile App`), make sure that the network activity is minimal and close to zero (ie. `Wall clock time spent on network requests | 0s`.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
