### PR TITLE
Add a check for missing `swiftlint_version:` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- `run_swiftlint`: Error gracefully when `swiftlint_version` is missing in the `.swiftlint.yml` file [#139]
 
 ### Internal Changes
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.8.0:
+      - automattic/a8c-ci-toolkit#3.9.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.7.1`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.9.0`.
 
 ## Configuration
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -21,6 +21,10 @@ if [[ $# -gt 0 ]]; then
 fi
 
 SWIFTLINT_VERSION="$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')"
+if [ -z "$SWIFTLINT_VERSION" ]; then
+  echo "Your \`.swiftlint.yml\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
+  exit 1
+fi
 SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION" swiftlint)
 
 set +e


### PR DESCRIPTION
Add a check for missing `swiftlint_version:` key, so that if it's missing we exit gracefully instead of having `docker run` error complaining about invalid syntax

[Internal Ref]: This came up as part of p1736899091552619/1736896890.515319-slack-CC7L49W13

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.