### PR TITLE
[Dependency Cache] Test Custom Init Gradle Task to Download Dependencies

### DIFF
--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_TEST"
 
 echo "Restoring Gradle dependency cache..."
 

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
-GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"
+GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_TEST"
 
 echo "Saving Gradle dependency cache..."
 


### PR DESCRIPTION
Related: [WCAndroid#13387](https://github.com/woocommerce/woocommerce-android/pull/13387)

FYI: This change is done for testing purposes only, and in order to verify that the newly added `init.gradle.kts` script is working as expected.

PS: This change with be tested only on `android-staging` agents.

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
