### PR TITLE
Typo fix in log of `prepare_windows_host_for_node.ps1`

### DIFF
--- a/bin/prepare_windows_host_for_node.ps1
+++ b/bin/prepare_windows_host_for_node.ps1
@@ -13,7 +13,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     $roles | ForEach-Object { Write-Host "  - $_" }
 }
 
-Write-Host "--- :windows: Setting up Windows for Node and Electorn builds"
+Write-Host "--- :windows: Setting up Windows for Node and Electron builds"
 
 Write-Host "Enable long path behavior"
 # See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation


### PR DESCRIPTION
Noticed while reviewing https://github.com/Automattic/studio/pull/875#pullrequestreview-2592863734 and comparing it with the content in https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/100/files#diff-7598495615634f329ebc6073c83d91279c85797e845fa9d0d303b6a7ce255e6f

- [ ] ~I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.~ ➡️  considered not worth it for just a typo fix.
