### PR TITLE
Do not echo three dashes at the end of restore cache script

### DIFF
--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -22,5 +22,3 @@ if [ -d "$DEP_CACHE_FOLDER_NAME/modules-2/" ]; then
 fi
 
 popd
-
-echo "---"

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -24,5 +24,3 @@ pushd "$DEP_CACHE_BASE_FOLDER"
 # For now we are using a single key - we might expand on this later by using dependency catalog version
 save_cache "$DEP_CACHE_FOLDER_NAME" "$GRADLE_DEPENDENCY_CACHE_KEY" --force
 popd
-
-echo "---"


### PR DESCRIPTION
This conflicts with Buildkite's terminal-to-html render

#### Build with an issue

![image](https://github.com/user-attachments/assets/8fa60f86-2a78-4859-9ed6-a20c893e52f2)

#### Fixed

<img width="1236" alt="image" src="https://github.com/user-attachments/assets/b82b1bc8-2b4e-4df0-950c-5525ea3714a4" />




---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
