### PR TITLE
Release 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add `pr_changed_files` command to detect changes made in a Pull Request [#148]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 3.11.0
+
+### New Features
+
+- Add `pr_changed_files` command to detect changes made in a Pull Request [#148]
 
 ## 3.10.1
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.10.1:
+      - automattic/a8c-ci-toolkit#3.11.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.10.1`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.11.0`.
 
 ## Configuration
 


### PR DESCRIPTION
- Update version number in README.md from 3.10.1 to 3.11.0
- Update CHANGELOG.md to prepare for 3.11.0 release


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
