### PR TITLE
Enhance pr_changed_files with exit codes and string output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Enhance `pr_changed_files` command to support both exit codes (default) and "true"/"false" string output (via `--stdout` flag) [#151]
 
 ### Bug Fixes
 

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -12,39 +12,53 @@
 #   1: Condition is not met (no files changed / patterns not matched)
 # 255: Error in command invocation (bad parameters, not in PR context, etc.)
 #
+# Output:
+#   In addition to exit codes, the script also outputs "true" or "false" to stdout
+#   when the condition is met or not met respectively.
+#
+# Typical usage patterns:
+#   # To assign the result to a variable — use `|| true` if your shell has `set -e` enabled
+#   $ DOC_UPDATED=$(pr_changed_files --any-match docs/* *.md || true)
+#
+#   # To use in an `if` condition — use `>/dev/null` to avoid the true/false output
+#   $ if pr_changed_files --any-match docs/* *.md >/dev/null; then
+#       echo "Documentation was updated"
+#     fi
+#
 # Behavior:
 #   With no arguments:
-#     Returns 0 if the PR contains any changes, 1 otherwise
+#     Returns exit code 0 (outputs "true") if the PR contains any changes
+#     Returns exit code 1 (outputs "false") if no changes
 #
 #   With --all-match:
-#     Returns 0 if ALL changed files match AT LEAST ONE of the patterns
-#     Returns 1 if ANY changed file doesn't match ANY pattern
+#     Returns exit code 0 (outputs "true") if ALL changed files match AT LEAST ONE of the patterns
+#     Returns exit code 1 (outputs "false") if ANY changed file doesn't match ANY pattern
 #     Note: Will return 0 even if not all patterns are matched by the changed files.
 #           This mode is especially useful to check if the PR _only_ touches a particular subset of files/folders (but nothing else)
 #
 #   With --any-match:
-#     Returns 0 if ANY changed file matches ANY of the patterns
-#     Returns 1 if NONE of the changed files match ANY pattern
+#     Returns exit code 0 (outputs "true") if ANY changed file matches ANY of the patterns
+#     Returns exit code 1 (outputs "false") if NONE of the changed files match ANY pattern
 #     Note: Will return 0 even if the PR includes other files not matching the patterns.
 #           This mode is especially useful to check if the PR _includes_ (aka _contains at least_) particular files/folders
 #
 # Examples with expected outputs:
 #   # Check if any files changed
 #   $ pr_changed_files
-#   → exit code 0 if PR has changes
-#   → exit code 1 if PR has no changes
+#   → exit code 0 (outputs "true") if PR has changes
+#   → exit code 1 (outputs "false") if PR has no changes
 #
 #   # Check if only documentation files changed (to skip UI tests for example)
 #   $ pr_changed_files --all-match "*.md" "docs/*"
-#   → exit code 0 if PR only changes `docs/guide.md` and `README.md`
-#   → exit code 0 if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
-#   → exit code 1 if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
+#   → exit code 0 (outputs "true") if PR only changes `docs/guide.md` and `README.md`
+#   → exit code 0 (outputs "true") if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
+#   → exit code 1 (outputs "false") if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
 #
 #   # Check if any Swift files changed (to decide if we should run SwiftLint)
 #   $ pr_changed_files --any-match "*.swift" ".swiftlint.yml"
-#   → exit code 0 if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
-#   → exit code 0 if PR changes `.swiftlint.yml`
-#   → exit code 1 if PR only changes `README.md` (none of files match any of the patterns)
+#   → exit code 0 (outputs "true") if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
+#   → exit code 0 (outputs "true") if PR changes `.swiftlint.yml`
+#   → exit code 1 (outputs "false") if PR only changes `README.md` (none of files match any of the patterns)
 
 if [[ ! "${BUILDKITE_PULL_REQUEST:-invalid}" =~ ^[0-9]+$ ]]; then
     echo "Error: this tool can only be called from a Buildkite PR job" >&2

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -6,6 +6,7 @@
 #   pr_changed_files                                  # Check if any files changed
 #   pr_changed_files --all-match <file-patterns...>   # Check if changes are limited to given patterns
 #   pr_changed_files --any-match <file-patterns...>   # Check if changes include files matching patterns
+#   pr_changed_files [--stdout] ...                   # Add --stdout to output "true"/"false" to stdout
 #
 # Exit codes:
 #   0: Condition is met (files changed / patterns matched)
@@ -13,17 +14,17 @@
 # 255: Error in command invocation (bad parameters, not in PR context, etc.)
 #
 # Output:
-#   In addition to exit codes, the script also outputs "true" or "false" to stdout
-#   when the condition is met or not met respectively.
+#   If the flag --stdout is used, the script will output "true" or "false" to stdout
+#   when the condition is met or not met respectively, and will return exit code 0.
 #
 # Typical usage patterns:
-#   # To assign the result to a variable — use `|| true` if your shell has `set -e` enabled
-#   $ DOC_UPDATED=$(pr_changed_files --any-match docs/* *.md || true)
-#
-#   # To use in an `if` condition — use `>/dev/null` to avoid the true/false output
-#   $ if pr_changed_files --any-match docs/* *.md >/dev/null; then
+#   # Using exit codes
+#   $ if pr_changed_files --any-match docs/* *.md; then
 #       echo "Documentation was updated"
 #     fi
+#
+#   # Using stdout output
+#   $ DOCS_UPDATED=$(pr_changed_files --stdout --any-match docs/* *.md)
 #
 # Behavior:
 #   With no arguments:
@@ -73,12 +74,17 @@ git fetch origin "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" >/dev/null 2>&1 || {
 
 mode=""
 patterns=()
+use_stdout="false"
 
 # Define error message for mutually exclusive options
 EXCLUSIVE_OPTIONS_ERROR="Error: either specify --all-match or --any-match; cannot specify both"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --stdout)
+            use_stdout="true"
+            shift
+            ;;
         --all-match | --any-match)
             if [[ -n "$mode" ]]; then
                 echo "$EXCLUSIVE_OPTIONS_ERROR" >&2
@@ -113,14 +119,26 @@ while IFS= read -r -d '' file; do
   changed_files+=("$file")
 done < <(git --no-pager diff --name-only -z --merge-base "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" HEAD | sort)
 
+exit_result() {
+    local result=$1
+    if [[ "$use_stdout" == "true" ]]; then
+        if [[ "$result" -eq 0 ]]; then
+            echo "true"
+        else
+            echo "false"
+        fi
+        exit 0
+    fi
+
+    exit $result
+}
+
 if [[ -z "$mode" ]]; then
     # No arguments = any change
     if [[ ${#changed_files[@]} -gt 0 ]]; then
-        echo "true"
-        exit 0
+        exit_result 0
     else
-        echo "false"
-        exit 1
+        exit_result 1
     fi
 fi
 
@@ -141,20 +159,16 @@ if [[ "$mode" == "all-match" ]]; then
     # Check if all changed files match at least one pattern
     for file in "${changed_files[@]}"; do
         if ! file_matches_any_pattern "$file" "${patterns[@]}"; then
-            echo "false"
-            exit 1
+            exit_result 1
         fi
     done
-    echo "true"
-    exit 0
+    exit_result 0
 elif [[ "$mode" == "any-match" ]]; then
     # Check if any changed file matches any pattern
     for file in "${changed_files[@]}"; do
         if file_matches_any_pattern "$file" "${patterns[@]}"; then
-            echo "true"
-            exit 0
+            exit_result 0
         fi
     done
-    echo "false"
-    exit 1
+    exit_result 1
 fi

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -7,52 +7,54 @@
 #   pr_changed_files --all-match <file-patterns...>   # Check if changes are limited to given patterns
 #   pr_changed_files --any-match <file-patterns...>   # Check if changes include files matching patterns
 #
+# Exit codes:
+#   0: Condition is met (files changed / patterns matched)
+#   1: Condition is not met (no files changed / patterns not matched)
+# 255: Error in command invocation (bad parameters, not in PR context, etc.)
+#
 # Behavior:
 #   With no arguments:
-#     Returns "true" if the PR contains any changes, "false" otherwise
+#     Returns 0 if the PR contains any changes, 1 otherwise
 #
 #   With --all-match:
-#     Returns "true" if ALL changed files match AT LEAST ONE of the patterns
-#     Returns "false" if ANY changed file doesn't match ANY pattern
-#     Note: Will return "true" even if not all patterns are matched by the changed files.
+#     Returns 0 if ALL changed files match AT LEAST ONE of the patterns
+#     Returns 1 if ANY changed file doesn't match ANY pattern
+#     Note: Will return 0 even if not all patterns are matched by the changed files.
 #           This mode is especially useful to check if the PR _only_ touches a particular subset of files/folders (but nothing else)
 #
 #   With --any-match:
-#     Returns "true" if ANY changed file matches ANY of the patterns
-#     Returns "false" if NONE of the changed files match ANY pattern
-#     Note: Will return "true" even if the PR includes other files not matching the patterns.
+#     Returns 0 if ANY changed file matches ANY of the patterns
+#     Returns 1 if NONE of the changed files match ANY pattern
+#     Note: Will return 0 even if the PR includes other files not matching the patterns.
 #           This mode is especially useful to check if the PR _includes_ (aka _contains at least_) particular files/folders
 #
 # Examples with expected outputs:
-#   # Check if any files changed, returning "true" if PR has changes, "false" otherwise
+#   # Check if any files changed
 #   $ pr_changed_files
+#   → exit code 0 if PR has changes
+#   → exit code 1 if PR has no changes
 #
 #   # Check if only documentation files changed (to skip UI tests for example)
 #   $ pr_changed_files --all-match "*.md" "docs/*"
-#   → "true"  if PR only changes `docs/guide.md` and `README.md`
-#   → "true"  if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
-#   → "false" if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
+#   → exit code 0 if PR only changes `docs/guide.md` and `README.md`
+#   → exit code 0 if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
+#   → exit code 1 if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
 #
 #   # Check if any Swift files changed (to decide if we should run SwiftLint)
 #   $ pr_changed_files --any-match "*.swift" ".swiftlint.yml"
-#   → "true"  if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
-#   → "true"  if PR changes `.swiftlint.yml`
-#   → "false" if PR only changes `README.md` (none of files match any of the patterns)
-#
-# Returns:
-#   Prints "true" if the condition is met, "false" otherwise
-#   Exits with code 0 regardless of if the condition was met or not, to allow easy variable assignment.
-#   Only exits with non-zero if the command invocation itself was incorrect (called outside of a PR context, incorrect arguments…)
+#   → exit code 0 if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
+#   → exit code 0 if PR changes `.swiftlint.yml`
+#   → exit code 1 if PR only changes `README.md` (none of files match any of the patterns)
 
 if [[ ! "${BUILDKITE_PULL_REQUEST:-invalid}" =~ ^[0-9]+$ ]]; then
     echo "Error: this tool can only be called from a Buildkite PR job" >&2
-    exit 1
+    exit 255
 fi
 
 # Ensure we have the base branch locally
 git fetch origin "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" >/dev/null 2>&1 || {
     echo "Error: failed to fetch base branch '$BUILDKITE_PULL_REQUEST_BASE_BRANCH'" >&2
-    exit 1
+    exit 255
 }
 
 mode=""
@@ -66,7 +68,7 @@ while [[ "$#" -gt 0 ]]; do
         --all-match | --any-match)
             if [[ -n "$mode" ]]; then
                 echo "$EXCLUSIVE_OPTIONS_ERROR" >&2
-                exit 1
+                exit 255
             fi
             mode="${1#--}"
             shift
@@ -77,16 +79,16 @@ while [[ "$#" -gt 0 ]]; do
             done
             if [[ "${#patterns[@]}" -eq 0 ]]; then
                 echo "Error: must specify at least one file pattern" >&2
-                exit 1
+                exit 255
             fi
             ;;
         --*) 
             echo "Error: unknown option $1" >&2
-            exit 1
+            exit 255
             ;;
         *)
             echo "Error: unexpected argument $1" >&2
-            exit 1
+            exit 255
             ;;
     esac
 done
@@ -100,11 +102,10 @@ done < <(git --no-pager diff --name-only -z --merge-base "$BUILDKITE_PULL_REQUES
 if [[ -z "$mode" ]]; then
     # No arguments = any change
     if [[ ${#changed_files[@]} -gt 0 ]]; then
-        echo "true"
+        exit 0
     else
-        echo "false"
+        exit 1
     fi
-    exit 0
 fi
 
 # Returns 0 if the file matches any of the patterns, 1 otherwise
@@ -124,18 +125,16 @@ if [[ "$mode" == "all-match" ]]; then
     # Check if all changed files match at least one pattern
     for file in "${changed_files[@]}"; do
         if ! file_matches_any_pattern "$file" "${patterns[@]}"; then
-            echo "false"
-            exit 0
+            exit 1
         fi
     done
-    echo "true"
+    exit 0
 elif [[ "$mode" == "any-match" ]]; then
     # Check if any changed file matches any pattern
     for file in "${changed_files[@]}"; do
         if file_matches_any_pattern "$file" "${patterns[@]}"; then
-            echo "true"
             exit 0
         fi
     done
-    echo "false"
+    exit 1
 fi

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -102,8 +102,10 @@ done < <(git --no-pager diff --name-only -z --merge-base "$BUILDKITE_PULL_REQUES
 if [[ -z "$mode" ]]; then
     # No arguments = any change
     if [[ ${#changed_files[@]} -gt 0 ]]; then
+        echo "true"
         exit 0
     else
+        echo "false"
         exit 1
     fi
 fi
@@ -125,16 +127,20 @@ if [[ "$mode" == "all-match" ]]; then
     # Check if all changed files match at least one pattern
     for file in "${changed_files[@]}"; do
         if ! file_matches_any_pattern "$file" "${patterns[@]}"; then
+            echo "false"
             exit 1
         fi
     done
+    echo "true"
     exit 0
 elif [[ "$mode" == "any-match" ]]; then
     # Check if any changed file matches any pattern
     for file in "${changed_files[@]}"; do
         if file_matches_any_pattern "$file" "${patterns[@]}"; then
+            echo "true"
             exit 0
         fi
     done
+    echo "false"
     exit 1
 fi

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -115,26 +115,28 @@ while IFS= read -r -d '' file; do
   changed_files+=("$file")
 done < <(git --no-pager diff --name-only -z --merge-base "$BUILDKITE_PULL_REQUEST_BASE_BRANCH" HEAD | sort)
 
-exit_result() {
-    local result=$1
+exit_true() {
     if [[ "$use_stdout" == "true" ]]; then
-        if [[ "$result" -eq 0 ]]; then
-            echo "true"
-        else
-            echo "false"
-        fi
+        echo "true"
         exit 0
     fi
+    exit 0
+}
 
-    exit "$result"
+exit_false() {
+    if [[ "$use_stdout" == "true" ]]; then
+        echo "false"
+        exit 0
+    fi
+    exit 1
 }
 
 if [[ -z "$mode" ]]; then
     # No arguments = any change
     if [[ ${#changed_files[@]} -gt 0 ]]; then
-        exit_result 0
+        exit_true
     else
-        exit_result 1
+        exit_false
     fi
 fi
 
@@ -155,16 +157,16 @@ if [[ "$mode" == "all-match" ]]; then
     # Check if all changed files match at least one pattern
     for file in "${changed_files[@]}"; do
         if ! file_matches_any_pattern "$file" "${patterns[@]}"; then
-            exit_result 1
+            exit_false
         fi
     done
-    exit_result 0
+    exit_true
 elif [[ "$mode" == "any-match" ]]; then
     # Check if any changed file matches any pattern
     for file in "${changed_files[@]}"; do
         if file_matches_any_pattern "$file" "${patterns[@]}"; then
-            exit_result 0
+            exit_true
         fi
     done
-    exit_result 1
+    exit_false
 fi

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -6,16 +6,12 @@
 #   pr_changed_files                                  # Check if any files changed
 #   pr_changed_files --all-match <file-patterns...>   # Check if changes are limited to given patterns
 #   pr_changed_files --any-match <file-patterns...>   # Check if changes include files matching patterns
-#   pr_changed_files [--stdout] ...                   # Add --stdout to output "true"/"false" to stdout
+#   pr_changed_files [--stdout] ...                   # Add --stdout to output "true"/"false" to stdout instead of using exit code
 #
-# Exit codes:
-#   0: Condition is met (files changed / patterns matched)
-#   1: Condition is not met (no files changed / patterns not matched)
-# 255: Error in command invocation (bad parameters, not in PR context, etc.)
-#
-# Output:
-#   If the flag --stdout is used, the script will output "true" or "false" to stdout
-#   when the condition is met or not met respectively, and will return exit code 0.
+# Result
+#  - By default, the script exits with code 0 if the condition is met (files changed / patterns matched), 1 if not. This is typically ideal to use in `if` conditions.
+#  - If you use the `--stdout` flag, it will output "true" or "false" instead of using the exit code (and exit 0 in both cases). Useful to assign the result to an environment variable for example.
+#  - The script will exit with code 255 if there is an error in the command invocation (bad parameters, not in PR context, etc.)
 #
 # Typical usage patterns:
 #   # Using exit codes
@@ -28,38 +24,38 @@
 #
 # Behavior:
 #   With no arguments:
-#     Returns exit code 0 (outputs "true") if the PR contains any changes
-#     Returns exit code 1 (outputs "false") if no changes
+#     Returns exit code 0 (or outputs "true" with `--stdout`) if the PR contains any changes
+#     Returns exit code 1 (or outputs "false" with `--stdout`) if no changes
 #
 #   With --all-match:
-#     Returns exit code 0 (outputs "true") if ALL changed files match AT LEAST ONE of the patterns
-#     Returns exit code 1 (outputs "false") if ANY changed file doesn't match ANY pattern
-#     Note: Will return 0 even if not all patterns are matched by the changed files.
+#     Returns exit code 0 (or outputs "true" with `--stdout`) if ALL changed files match AT LEAST ONE of the patterns
+#     Returns exit code 1 (or outputs "false" with `--stdout`) if ANY changed file doesn't match ANY pattern
+#     Note: Will report success even if not all patterns are matched by the changed files.
 #           This mode is especially useful to check if the PR _only_ touches a particular subset of files/folders (but nothing else)
 #
 #   With --any-match:
-#     Returns exit code 0 (outputs "true") if ANY changed file matches ANY of the patterns
-#     Returns exit code 1 (outputs "false") if NONE of the changed files match ANY pattern
-#     Note: Will return 0 even if the PR includes other files not matching the patterns.
+#     Returns exit code 0 (or outputs "true" with `--stdout`) if ANY changed file matches ANY of the patterns
+#     Returns exit code 1 (or outputs "false" with `--stdout`) if NONE of the changed files match ANY pattern
+#     Note: Will report success even if the PR includes other files not matching the patterns.
 #           This mode is especially useful to check if the PR _includes_ (aka _contains at least_) particular files/folders
 #
 # Examples with expected outputs:
 #   # Check if any files changed
 #   $ pr_changed_files
-#   → exit code 0 (outputs "true") if PR has changes
-#   → exit code 1 (outputs "false") if PR has no changes
+#   → exit code 0 if PR has changes
+#   → exit code 1 if PR has no changes
 #
 #   # Check if only documentation files changed (to skip UI tests for example)
 #   $ pr_changed_files --all-match "*.md" "docs/*"
-#   → exit code 0 (outputs "true") if PR only changes `docs/guide.md` and `README.md`
-#   → exit code 0 (outputs "true") if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
-#   → exit code 1 (outputs "false") if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
+#   → exit code 0 if PR only changes `docs/guide.md` and `README.md`
+#   → exit code 0 if PR only changes `docs/image.png` (not all patterns need to match, ok if no *.md)
+#   → exit code 1 if PR changes `docs/guide.md` and `src/main.swift` (ALL files need to match at least one pattern)
 #
 #   # Check if any Swift files changed (to decide if we should run SwiftLint)
 #   $ pr_changed_files --any-match "*.swift" ".swiftlint.yml"
-#   → exit code 0 (outputs "true") if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
-#   → exit code 0 (outputs "true") if PR changes `.swiftlint.yml`
-#   → exit code 1 (outputs "false") if PR only changes `README.md` (none of files match any of the patterns)
+#   → exit code 0 if PR changes `src/main.swift` and `README.md` (AT LEAST one file matches one of the patterns)
+#   → exit code 0 if PR changes `.swiftlint.yml`
+#   → exit code 1 if PR only changes `README.md` (none of files match any of the patterns)
 
 if [[ ! "${BUILDKITE_PULL_REQUEST:-invalid}" =~ ^[0-9]+$ ]]; then
     echo "Error: this tool can only be called from a Buildkite PR job" >&2

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -130,7 +130,7 @@ exit_result() {
         exit 0
     fi
 
-    exit $result
+    exit "$result"
 }
 
 if [[ -z "$mode" ]]; then

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -25,22 +25,37 @@ echo "doc3" > 'docs/special\!@*#$chars.md'
 git add .
 git commit -m "Add doc files"
 
-# [Test] All changes in docs
+# [Test] All changes in docs - exit code only
 output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns"
+assert_result 0 $result "$output" "" "Should match when all changes are in docs"
 
-# [Test] All changes in docs with explicit patterns including spaces and special chars
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/*')
+result=$?
+assert_result 0 $result "$output" "true" "Should match when all changes are in docs with --stdout"
+
+# [Test] All changes in docs with explicit patterns including spaces and special chars - exit code only
 output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with spaces and special chars"
+assert_result 0 $result "$output" "" "Should match when all changes match patterns with spaces and special chars"
 
-# [Test] All changes in docs with globbing patterns including spaces and special chars
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
+result=$?
+assert_result 0 $result "$output" "true" "Should match when all changes match patterns with spaces and special chars with --stdout"
+
+# [Test] All changes in docs with globbing patterns including spaces and special chars - exit code only
 output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with globbing"
+assert_result 0 $result "$output" "" "Should match when all changes match patterns with globbing"
 
-# [Test] Changes outside pattern
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
+result=$?
+assert_result 0 $result "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
+
+# [Test] Changes outside pattern - exit code only
 echo "swift" > 'src/swift/main with spaces.swift'
 echo "swift" > 'src/swift/special!\@#*$chars.swift'
 git add .
@@ -48,26 +63,31 @@ git commit -m "Add swift file"
 
 output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when changes exist outside patterns"
+assert_result 1 $result "$output" "" "Should not match when changes exist outside patterns"
 
-# [Test] Multiple patterns, all matching
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/*')
+result=$?
+assert_result 0 $result "$output" "false" "Should not match when changes exist outside patterns with --stdout"
+
+# [Test] Multiple patterns, all matching - exit code only
 output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match multiple patterns"
+assert_result 0 $result "$output" "" "Should match when all changes match multiple patterns"
 
-# [Test] Multiple patterns, all matching, including some using globbing
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
+result=$?
+assert_result 0 $result "$output" "true" "Should match when all changes match multiple patterns with --stdout"
+
+# [Test] Multiple patterns, all matching, including some using globbing - exit code only
 output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with globbing"
+assert_result 0 $result "$output" "" "Should match when all changes match patterns with globbing"
 
-# [Test] Changes outside pattern - check output string
-echo "swift" > 'src/swift/main with spaces.swift'
-echo "swift" > 'src/swift/special!\@#*$chars.swift'
-git add .
-git commit -m "Add swift file"
-
-output=$(pr_changed_files --all-match 'docs/*')
+# Test with stdout
+output=$(pr_changed_files --stdout --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when changes exist outside patterns"
+assert_result 0 $result "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
 
 echo "✅ All-match pattern tests passed"

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -28,18 +28,18 @@ git commit -m "Add doc files"
 # [Test] All changes in docs
 pr_changed_files --all-match "docs/*"
 result=$?
-assert_return_code 0 $result "Should return true when all changes match patterns"
+assert_return_code 0 $result "Should return 0 when all changes match patterns"
 
 # [Test] All changes in docs with explicit patterns including spaces and special chars
 # Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
 pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md'
 result=$?
-assert_return_code 0 $result "Should return true when all changes match patterns with spaces and special chars"
+assert_return_code 0 $result "Should return 0 when all changes match patterns with spaces and special chars"
 
 # [Test] All changes in docs with globbing patterns including spaces and special chars
 pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md'
 result=$?
-assert_return_code 0 $result "Should return true when all changes match patterns with spaces and special chars, even when using globbing"
+assert_return_code 0 $result "Should return 0 when all changes match patterns with spaces and special chars, even when using globbing"
 
 # [Test] Changes outside pattern
 echo "swift" > 'src/swift/main with spaces.swift'
@@ -55,11 +55,23 @@ assert_return_code 1 $result "Should return false when changes exist outside pat
 # Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
 pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift'
 result=$?
-assert_return_code 0 $result "Should return true when all changes match multiple patterns"
+assert_return_code 0 $result "Should return 0 when all changes match multiple patterns"
 
 # [Test] Multiple patterns, all matching, including some using globbing
-pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift'
+output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_return_code 0 $result "Should return true when all changes match multiple patterns, including some using globbing"
+assert_return_code 0 $result "Should return 0 when all changes match multiple patterns, including some using globbing"
+assert_output "true" "$output" "Should output 'true' string when all changes match patterns"
+
+# [Test] Changes outside pattern - check output string
+echo "swift" > 'src/swift/main with spaces.swift'
+echo "swift" > 'src/swift/special!\@#*$chars.swift'
+git add .
+git commit -m "Add swift file"
+
+output=$(pr_changed_files --all-match "docs/*")
+result=$?
+assert_return_code 1 $result "Should return false when changes exist outside patterns"
+assert_output "false" "$output" "Should output 'false' string when changes exist outside patterns"
 
 echo "✅ All-match pattern tests passed"

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -26,20 +26,19 @@ git add .
 git commit -m "Add doc files"
 
 # [Test] All changes in docs
-pr_changed_files --all-match "docs/*"
+output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_return_code 0 $result "Should return 0 when all changes match patterns"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns"
 
 # [Test] All changes in docs with explicit patterns including spaces and special chars
-# Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
-pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md'
+output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
 result=$?
-assert_return_code 0 $result "Should return 0 when all changes match patterns with spaces and special chars"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with spaces and special chars"
 
 # [Test] All changes in docs with globbing patterns including spaces and special chars
-pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md'
+output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
 result=$?
-assert_return_code 0 $result "Should return 0 when all changes match patterns with spaces and special chars, even when using globbing"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with globbing"
 
 # [Test] Changes outside pattern
 echo "swift" > 'src/swift/main with spaces.swift'
@@ -47,21 +46,19 @@ echo "swift" > 'src/swift/special!\@#*$chars.swift'
 git add .
 git commit -m "Add swift file"
 
-pr_changed_files --all-match "docs/*"
+output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_return_code 1 $result "Should return false when changes exist outside patterns"
+assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when changes exist outside patterns"
 
 # [Test] Multiple patterns, all matching
-# Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
-pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift'
+output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
 result=$?
-assert_return_code 0 $result "Should return 0 when all changes match multiple patterns"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match multiple patterns"
 
 # [Test] Multiple patterns, all matching, including some using globbing
 output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_return_code 0 $result "Should return 0 when all changes match multiple patterns, including some using globbing"
-assert_output "true" "$output" "Should output 'true' string when all changes match patterns"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when all changes match patterns with globbing"
 
 # [Test] Changes outside pattern - check output string
 echo "swift" > 'src/swift/main with spaces.swift'
@@ -69,9 +66,8 @@ echo "swift" > 'src/swift/special!\@#*$chars.swift'
 git add .
 git commit -m "Add swift file"
 
-output=$(pr_changed_files --all-match "docs/*")
+output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_return_code 1 $result "Should return false when changes exist outside patterns"
-assert_output "false" "$output" "Should output 'false' string when changes exist outside patterns"
+assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when changes exist outside patterns"
 
 echo "✅ All-match pattern tests passed"

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -28,12 +28,12 @@ git commit -m "Add doc files"
 # [Test] All changes in docs - exit code only
 output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "" "Should match when all changes are in docs"
+assert_result 0 $result "" "$output" "Should match when all changes are in docs"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "true" "Should match when all changes are in docs with --stdout"
+assert_result 0 $result "true" "$output" "Should match when all changes are in docs with --stdout"
 
 # [Test] All changes in docs with explicit patterns including spaces and special chars - exit code only
 output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -28,32 +28,32 @@ git commit -m "Add doc files"
 # [Test] All changes in docs - exit code only
 output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_result 0 $result "" "$output" "Should match when all changes are in docs"
+assert_result $result 0 "$output" "" "Should match when all changes are in docs"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/*')
 result=$?
-assert_result 0 $result "true" "$output" "Should match when all changes are in docs with --stdout"
+assert_result $result 0 "$output" "true" "Should match when all changes are in docs with --stdout"
 
 # [Test] All changes in docs with explicit patterns including spaces and special chars - exit code only
 output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "" "Should match when all changes match patterns with spaces and special chars"
+assert_result $result 0 "$output" "" "Should match when all changes match patterns with spaces and special chars"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should match when all changes match patterns with spaces and special chars with --stdout"
+assert_result $result 0 "$output" "true" "Should match when all changes match patterns with spaces and special chars with --stdout"
 
 # [Test] All changes in docs with globbing patterns including spaces and special chars - exit code only
 output=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
 result=$?
-assert_result 0 $result "$output" "" "Should match when all changes match patterns with globbing"
+assert_result $result 0 "$output" "" "Should match when all changes match patterns with globbing"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
+assert_result $result 0 "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
 
 # [Test] Changes outside pattern - exit code only
 echo "swift" > 'src/swift/main with spaces.swift'
@@ -63,31 +63,31 @@ git commit -m "Add swift file"
 
 output=$(pr_changed_files --all-match 'docs/*')
 result=$?
-assert_result 1 $result "$output" "" "Should not match when changes exist outside patterns"
+assert_result $result 1 "$output" "" "Should not match when changes exist outside patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "false" "Should not match when changes exist outside patterns with --stdout"
+assert_result $result 0 "$output" "false" "Should not match when changes exist outside patterns with --stdout"
 
 # [Test] Multiple patterns, all matching - exit code only
 output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
 result=$?
-assert_result 0 $result "$output" "" "Should match when all changes match multiple patterns"
+assert_result $result 0 "$output" "" "Should match when all changes match multiple patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should match when all changes match multiple patterns with --stdout"
+assert_result $result 0 "$output" "true" "Should match when all changes match multiple patterns with --stdout"
 
 # [Test] Multiple patterns, all matching, including some using globbing - exit code only
 output=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_result 0 $result "$output" "" "Should match when all changes match patterns with globbing"
+assert_result $result 0 "$output" "" "Should match when all changes match patterns with globbing"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
+assert_result $result 0 "$output" "true" "Should match when all changes match patterns with globbing with --stdout"
 
 echo "✅ All-match pattern tests passed"

--- a/tests/pr_changed_files/test_all_match_patterns.sh
+++ b/tests/pr_changed_files/test_all_match_patterns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -u
 
 set -o pipefail
 
@@ -26,17 +26,20 @@ git add .
 git commit -m "Add doc files"
 
 # [Test] All changes in docs
-result=$(pr_changed_files --all-match "docs/*")
-assert_output "true" "$result" "Should return true when all changes match patterns"
+pr_changed_files --all-match "docs/*"
+result=$?
+assert_return_code 0 $result "Should return true when all changes match patterns"
 
 # [Test] All changes in docs with explicit patterns including spaces and special chars
 # Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
-result=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md')
-assert_output "true" "$result" "Should return true when all changes match patterns with spaces and special chars"
+pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!@\*#$chars.md'
+result=$?
+assert_return_code 0 $result "Should return true when all changes match patterns with spaces and special chars"
 
 # [Test] All changes in docs with globbing patterns including spaces and special chars
-result=$(pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md')
-assert_output "true" "$result" "Should return true when all changes match patterns with spaces and special chars, even when using globbing"
+pr_changed_files --all-match 'docs/read me.md' 'docs/guide with spaces.md' 'docs/special\\!*.md'
+result=$?
+assert_return_code 0 $result "Should return true when all changes match patterns with spaces and special chars, even when using globbing"
 
 # [Test] Changes outside pattern
 echo "swift" > 'src/swift/main with spaces.swift'
@@ -44,16 +47,19 @@ echo "swift" > 'src/swift/special!\@#*$chars.swift'
 git add .
 git commit -m "Add swift file"
 
-result=$(pr_changed_files --all-match "docs/*")
-assert_output "false" "$result" "Should return false when changes exist outside patterns"
+pr_changed_files --all-match "docs/*"
+result=$?
+assert_return_code 1 $result "Should return false when changes exist outside patterns"
 
 # [Test] Multiple patterns, all matching
 # Note: we need to escape the '\` and `*` special chars in the pattern to match them literally instead of as special characters
-result=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift')
-assert_output "true" "$result" "Should return true when all changes match multiple patterns"
+pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special\!\\@#\*$chars.swift'
+result=$?
+assert_return_code 0 $result "Should return true when all changes match multiple patterns"
 
 # [Test] Multiple patterns, all matching, including some using globbing
-result=$(pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift')
-assert_output "true" "$result" "Should return true when all changes match multiple patterns, including some using globbing"
+pr_changed_files --all-match 'docs/*' 'src/swift/main with spaces.swift' 'src/swift/special*chars.swift'
+result=$?
+assert_return_code 0 $result "Should return true when all changes match multiple patterns, including some using globbing"
 
 echo "✅ All-match pattern tests passed"

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -26,10 +26,11 @@ echo "ruby" > 'src/ruby/main.rb'
 git add .
 git commit -m "Add test files"
 
-# [Test] Match specific extension
-pr_changed_files --any-match '*.swift'
+# [Test] Match specific extension - check output string
+output=$(pr_changed_files --any-match '*.swift')
 result=$?
 assert_return_code 0 $result "Should match .swift files"
+assert_output "true" "$output" "Should output 'true' string when matching .swift files"
 
 # [Test] Match multiple patterns
 pr_changed_files --any-match 'docs/*.md' '*.rb'
@@ -46,10 +47,11 @@ pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md'
 result=$?
 assert_return_code 0 $result "Should match files with spaces and special characters, even when using globbing"
 
-# [Test] No matches
-pr_changed_files --any-match '*.js'
+# [Test] No matches - check output string
+output=$(pr_changed_files --any-match '*.js')
 result=$?
 assert_return_code 1 $result "Should not match non-existent patterns"
+assert_output "false" "$output" "Should output 'false' string when no patterns match"
 
 # [Test] Directory pattern
 pr_changed_files --any-match 'docs/*'

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -u
 
 set -o pipefail
 
@@ -27,35 +27,42 @@ git add .
 git commit -m "Add test files"
 
 # [Test] Match specific extension
-result=$(pr_changed_files --any-match '*.swift')
-assert_output "true" "$result" "Should match .swift files"
+pr_changed_files --any-match '*.swift'
+result=$?
+assert_return_code 0 $result "Should match .swift files"
 
 # [Test] Match multiple patterns
-result=$(pr_changed_files --any-match 'docs/*.md' '*.rb')
-assert_output "true" "$result" "Should match multiple patterns"
+pr_changed_files --any-match 'docs/*.md' '*.rb'
+result=$?
+assert_return_code 0 $result "Should match multiple patterns"
 
 # [Test] Match files with spaces and special characters
-result=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special!@\*#$chars.md')
-assert_output "true" "$result" "Should match files with spaces and special characters"
+pr_changed_files --any-match 'docs/read me.md' 'docs/special!@\*#$chars.md'
+result=$?
+assert_return_code 0 $result "Should match files with spaces and special characters"
 
 # [Test] Match files with spaces and special characters, even when using globbing
-result=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md')
-assert_output "true" "$result" "Should match files with spaces and special characters, even when using globbing"
+pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md'
+result=$?
+assert_return_code 0 $result "Should match files with spaces and special characters, even when using globbing"
 
 # [Test] No matches
-result=$(pr_changed_files --any-match '*.js')
-assert_output "false" "$result" "Should not match non-existent patterns"
+pr_changed_files --any-match '*.js'
+result=$?
+assert_return_code 1 $result "Should not match non-existent patterns"
 
 # [Test] Directory pattern
-result=$(pr_changed_files --any-match 'docs/*')
-assert_output "true" "$result" "Should match directory patterns"
+pr_changed_files --any-match 'docs/*'
+result=$?
+assert_return_code 0 $result "Should match directory patterns"
 
 # [Test] Exact pattern matching
 echo "swiftfile" > swiftfile.txt
 git add swiftfile.txt
 git commit -m "Add file with swift in name"
 
-result=$(pr_changed_files --any-match '*.swift')
-assert_output "true" "$result" "Should only match exact patterns"
+pr_changed_files --any-match '*.swift'
+result=$?
+assert_return_code 0 $result "Should only match exact patterns"
 
 echo "✅ Any-match pattern tests passed"

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -39,42 +39,42 @@ assert_result $result 0 "$output" "true" "Should match .swift files with --stdou
 # [Test] Match multiple patterns - exit code only
 output=$(pr_changed_files --any-match 'docs/*.md' '*.rb')
 result=$?
-assert_result 0 $result "$output" "" "Should match multiple patterns"
+assert_result $result 0 "$output" "" "Should match multiple patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match 'docs/*.md' '*.rb')
 result=$?
-assert_result 0 $result "$output" "true" "Should match multiple patterns with --stdout"
+assert_result $result 0 "$output" "true" "Should match multiple patterns with --stdout"
 
 # [Test] Match files with spaces and special characters - exit code only
 output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special!@*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "" "Should match files with spaces and special characters"
+assert_result $result 0 "$output" "" "Should match files with spaces and special characters"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match 'docs/read me.md' 'docs/special!@*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should match files with spaces and special characters with --stdout"
+assert_result $result 0 "$output" "true" "Should match files with spaces and special characters with --stdout"
 
 # [Test] No matches - exit code only
 output=$(pr_changed_files --any-match '*.js')
 result=$?
-assert_result 1 $result "$output" "" "Should not match non-existent patterns"
+assert_result $result 1 "$output" "" "Should not match non-existent patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match '*.js')
 result=$?
-assert_result 0 $result "$output" "false" "Should not match non-existent patterns with --stdout"
+assert_result $result 0 "$output" "false" "Should not match non-existent patterns with --stdout"
 
 # [Test] Directory pattern - exit code only
 output=$(pr_changed_files --any-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "" "Should match directory patterns"
+assert_result $result 0 "$output" "" "Should match directory patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "true" "Should match directory patterns with --stdout"
+assert_result $result 0 "$output" "true" "Should match directory patterns with --stdout"
 
 # [Test] Exact pattern matching - exit code only
 echo "swiftfile" > swiftfile.txt
@@ -83,11 +83,11 @@ git commit -m "Add file with swift in name"
 
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "" "Should only match exact patterns"
+assert_result $result 0 "$output" "" "Should only match exact patterns"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should only match exact patterns with --stdout"
+assert_result $result 0 "$output" "true" "Should only match exact patterns with --stdout"
 
 echo "✅ Any-match pattern tests passed"

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -29,42 +29,40 @@ git commit -m "Add test files"
 # [Test] Match specific extension - check output string
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_return_code 0 $result "Should match .swift files"
-assert_output "true" "$output" "Should output 'true' string when matching .swift files"
+assert_result 0 $result "$output" "true" "Should match .swift files and output 'true'"
 
 # [Test] Match multiple patterns
-pr_changed_files --any-match 'docs/*.md' '*.rb'
+output=$(pr_changed_files --any-match 'docs/*.md' '*.rb')
 result=$?
-assert_return_code 0 $result "Should match multiple patterns"
+assert_result 0 $result "$output" "true" "Should match multiple patterns and output 'true'"
 
 # [Test] Match files with spaces and special characters
-pr_changed_files --any-match 'docs/read me.md' 'docs/special!@\*#$chars.md'
+output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special!@\*#$chars.md')
 result=$?
-assert_return_code 0 $result "Should match files with spaces and special characters"
+assert_result 0 $result "$output" "true" "Should match files with spaces and special characters and output 'true'"
 
 # [Test] Match files with spaces and special characters, even when using globbing
-pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md'
+output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md')
 result=$?
-assert_return_code 0 $result "Should match files with spaces and special characters, even when using globbing"
+assert_result 0 $result "$output" "true" "Should match files with spaces and special characters with globbing and output 'true'"
 
 # [Test] No matches - check output string
 output=$(pr_changed_files --any-match '*.js')
 result=$?
-assert_return_code 1 $result "Should not match non-existent patterns"
-assert_output "false" "$output" "Should output 'false' string when no patterns match"
+assert_result 1 $result "$output" "false" "Should not match non-existent patterns and output 'false'"
 
 # [Test] Directory pattern
-pr_changed_files --any-match 'docs/*'
+output=$(pr_changed_files --any-match 'docs/*')
 result=$?
-assert_return_code 0 $result "Should match directory patterns"
+assert_result 0 $result "$output" "true" "Should match directory patterns and output 'true'"
 
 # [Test] Exact pattern matching
 echo "swiftfile" > swiftfile.txt
 git add swiftfile.txt
 git commit -m "Add file with swift in name"
 
-pr_changed_files --any-match '*.swift'
+output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_return_code 0 $result "Should only match exact patterns"
+assert_result 0 $result "$output" "true" "Should only match exact patterns and output 'true'"
 
 echo "✅ Any-match pattern tests passed"

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -29,12 +29,12 @@ git commit -m "Add test files"
 # [Test] Match specific extension - exit code only
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "" "Should match .swift files"
+assert_result 0 $result "" "$output" "Should match .swift files"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should match .swift files with --stdout"
+assert_result 0 $result "true" "$output" "Should match .swift files with --stdout"
 
 # [Test] Match multiple patterns - exit code only
 output=$(pr_changed_files --any-match 'docs/*.md' '*.rb')

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -29,12 +29,12 @@ git commit -m "Add test files"
 # [Test] Match specific extension - exit code only
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_result 0 $result "" "$output" "Should match .swift files"
+assert_result $result 0 "$output" "" "Should match .swift files"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match '*.swift')
 result=$?
-assert_result 0 $result "true" "$output" "Should match .swift files with --stdout"
+assert_result $result 0 "$output" "true" "Should match .swift files with --stdout"
 
 # [Test] Match multiple patterns - exit code only
 output=$(pr_changed_files --any-match 'docs/*.md' '*.rb')

--- a/tests/pr_changed_files/test_any_match_patterns.sh
+++ b/tests/pr_changed_files/test_any_match_patterns.sh
@@ -26,43 +26,68 @@ echo "ruby" > 'src/ruby/main.rb'
 git add .
 git commit -m "Add test files"
 
-# [Test] Match specific extension - check output string
+# [Test] Match specific extension - exit code only
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should match .swift files and output 'true'"
+assert_result 0 $result "$output" "" "Should match .swift files"
 
-# [Test] Match multiple patterns
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match '*.swift')
+result=$?
+assert_result 0 $result "$output" "true" "Should match .swift files with --stdout"
+
+# [Test] Match multiple patterns - exit code only
 output=$(pr_changed_files --any-match 'docs/*.md' '*.rb')
 result=$?
-assert_result 0 $result "$output" "true" "Should match multiple patterns and output 'true'"
+assert_result 0 $result "$output" "" "Should match multiple patterns"
 
-# [Test] Match files with spaces and special characters
-output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special!@\*#$chars.md')
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match 'docs/*.md' '*.rb')
 result=$?
-assert_result 0 $result "$output" "true" "Should match files with spaces and special characters and output 'true'"
+assert_result 0 $result "$output" "true" "Should match multiple patterns with --stdout"
 
-# [Test] Match files with spaces and special characters, even when using globbing
-output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special*chars.md')
+# [Test] Match files with spaces and special characters - exit code only
+output=$(pr_changed_files --any-match 'docs/read me.md' 'docs/special!@*#$chars.md')
 result=$?
-assert_result 0 $result "$output" "true" "Should match files with spaces and special characters with globbing and output 'true'"
+assert_result 0 $result "$output" "" "Should match files with spaces and special characters"
 
-# [Test] No matches - check output string
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match 'docs/read me.md' 'docs/special!@*#$chars.md')
+result=$?
+assert_result 0 $result "$output" "true" "Should match files with spaces and special characters with --stdout"
+
+# [Test] No matches - exit code only
 output=$(pr_changed_files --any-match '*.js')
 result=$?
-assert_result 1 $result "$output" "false" "Should not match non-existent patterns and output 'false'"
+assert_result 1 $result "$output" "" "Should not match non-existent patterns"
 
-# [Test] Directory pattern
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match '*.js')
+result=$?
+assert_result 0 $result "$output" "false" "Should not match non-existent patterns with --stdout"
+
+# [Test] Directory pattern - exit code only
 output=$(pr_changed_files --any-match 'docs/*')
 result=$?
-assert_result 0 $result "$output" "true" "Should match directory patterns and output 'true'"
+assert_result 0 $result "$output" "" "Should match directory patterns"
 
-# [Test] Exact pattern matching
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match 'docs/*')
+result=$?
+assert_result 0 $result "$output" "true" "Should match directory patterns with --stdout"
+
+# [Test] Exact pattern matching - exit code only
 echo "swiftfile" > swiftfile.txt
 git add swiftfile.txt
 git commit -m "Add file with swift in name"
 
 output=$(pr_changed_files --any-match '*.swift')
 result=$?
-assert_result 0 $result "$output" "true" "Should only match exact patterns and output 'true'"
+assert_result 0 $result "$output" "" "Should only match exact patterns"
+
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match '*.swift')
+result=$?
+assert_result 0 $result "$output" "true" "Should only match exact patterns with --stdout"
 
 echo "✅ Any-match pattern tests passed"

--- a/tests/pr_changed_files/test_basic_changes.sh
+++ b/tests/pr_changed_files/test_basic_changes.sh
@@ -17,18 +17,28 @@ export BUILDKITE_PULL_REQUEST_BASE_BRANCH="base"
 # Initialize the repository
 init_test_repo "$repo_path"
 
-# [Test] No changes
+# [Test] No changes - exit code only
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when no files changed"
+assert_result 1 $result "$output" "" "Should return 1 when no files changed"
 
-# [Test] Single file change
+# [Test] No changes - with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "false" "Should output 'false' and return 0 with --stdout when no files changed"
+
+# [Test] Single file change - exit code only
 echo "change" > new.txt
 git add new.txt
 git commit -m "Add new file"
 
 output=$(pr_changed_files)
 result=$?
-assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when files changed"
+assert_result 0 $result "$output" "" "Should return 0 when files changed"
+
+# [Test] Single file change - with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "true" "Should output 'true' and return 0 with --stdout when files changed"
 
 echo "✅ Basic changes tests passed"

--- a/tests/pr_changed_files/test_basic_changes.sh
+++ b/tests/pr_changed_files/test_basic_changes.sh
@@ -20,12 +20,12 @@ init_test_repo "$repo_path"
 # [Test] No changes - exit code only
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "" "$output" "Should return 1 when no files changed"
+assert_result $result 1 "$output" "" "Should return 1 when no files changed"
 
 # [Test] No changes - with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "false" "$output" "Should output 'false' and return 0 with --stdout when no files changed"
+assert_result $result 0 "$output" "false" "Should output 'false' and return 0 with --stdout when no files changed"
 
 # [Test] Single file change - exit code only
 echo "change" > new.txt
@@ -34,11 +34,11 @@ git commit -m "Add new file"
 
 output=$(pr_changed_files)
 result=$?
-assert_result 0 $result "$output" "" "Should return 0 when files changed"
+assert_result $result 0 "$output" "" "Should return 0 when files changed"
 
 # [Test] Single file change - with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "true" "Should output 'true' and return 0 with --stdout when files changed"
+assert_result $result 0 "$output" "true" "Should output 'true' and return 0 with --stdout when files changed"
 
 echo "✅ Basic changes tests passed"

--- a/tests/pr_changed_files/test_basic_changes.sh
+++ b/tests/pr_changed_files/test_basic_changes.sh
@@ -18,17 +18,17 @@ export BUILDKITE_PULL_REQUEST_BASE_BRANCH="base"
 init_test_repo "$repo_path"
 
 # [Test] No changes
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 1 $result "Should return 1 when no files changed"
+assert_result 1 $result "$output" "false" "Should return 1 and output 'false' when no files changed"
 
 # [Test] Single file change
 echo "change" > new.txt
 git add new.txt
 git commit -m "Add new file"
 
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 0 $result "Should return 0 when files changed"
+assert_result 0 $result "$output" "true" "Should return 0 and output 'true' when files changed"
 
 echo "✅ Basic changes tests passed"

--- a/tests/pr_changed_files/test_basic_changes.sh
+++ b/tests/pr_changed_files/test_basic_changes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -u
 
 set -o pipefail
 
@@ -18,15 +18,17 @@ export BUILDKITE_PULL_REQUEST_BASE_BRANCH="base"
 init_test_repo "$repo_path"
 
 # [Test] No changes
-result=$(pr_changed_files)
-assert_output "false" "$result" "Should return false when no files changed"
+pr_changed_files
+result=$?
+assert_return_code 1 $result "Should return 1 when no files changed"
 
 # [Test] Single file change
 echo "change" > new.txt
 git add new.txt
 git commit -m "Add new file"
 
-result=$(pr_changed_files)
-assert_output "true" "$result" "Should return true when files changed"
+pr_changed_files
+result=$?
+assert_return_code 0 $result "Should return 0 when files changed"
 
 echo "✅ Basic changes tests passed"

--- a/tests/pr_changed_files/test_basic_changes.sh
+++ b/tests/pr_changed_files/test_basic_changes.sh
@@ -20,12 +20,12 @@ init_test_repo "$repo_path"
 # [Test] No changes - exit code only
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "" "Should return 1 when no files changed"
+assert_result 1 $result "" "$output" "Should return 1 when no files changed"
 
 # [Test] No changes - with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "false" "Should output 'false' and return 0 with --stdout when no files changed"
+assert_result 0 $result "false" "$output" "Should output 'false' and return 0 with --stdout when no files changed"
 
 # [Test] Single file change - exit code only
 echo "change" > new.txt

--- a/tests/pr_changed_files/test_edge_cases.sh
+++ b/tests/pr_changed_files/test_edge_cases.sh
@@ -47,39 +47,61 @@ echo "test" > 'folder with spaces/nested!\@*#$folder/file_with_!@*#$chars.txt'
 git add .
 git commit -m "Add files with special characters"
 
+# Test with exit code only
 output=$(pr_changed_files)
 result=$?
-assert_result 0 $result "$output" "true" "Should handle files with spaces and special characters"
+assert_result 0 $result "$output" "" "Should handle files with spaces and special characters"
 
-# [Test] Pattern matching with spaces and special characters
+# Test with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "true" "Should handle files with spaces and special characters with --stdout"
+
+# [Test] Pattern matching with spaces and special characters - exit code only
 output=$(pr_changed_files --any-match '*spaces.txt')
 result=$?
-assert_result 0 $result "$output" "true" "Should match files with special characters in path"
+assert_result 0 $result "$output" "" "Should match files with special characters in path"
 
-output=$(pr_changed_files --all-match 'folder with spaces/*')
+# Test with stdout
+output=$(pr_changed_files --stdout --any-match '*spaces.txt')
 result=$?
-assert_result 0 $result "$output" "true" "Should handle directory patterns with spaces"
+assert_result 0 $result "$output" "true" "Should match files with special characters in path with --stdout"
 
-# [Test] No changes between branches
+# [Test] No changes between branches - exit code only
 git checkout -b no_changes base
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "false" "Should handle no changes between branches"
+assert_result 1 $result "$output" "" "Should handle no changes between branches"
 
-# [Test] Empty commit
+# Test with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "false" "Should handle no changes between branches with --stdout"
+
+# [Test] Empty commit - exit code only
 git checkout -b empty_commit base
 git commit --allow-empty -m "Empty commit"
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "false" "Should handle empty commit"
+assert_result 1 $result "$output" "" "Should handle empty commit"
 
-# [Test] Empty repository state
+# Test with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "false" "Should handle empty commit with --stdout"
+
+# [Test] Empty repository state - exit code only
 git checkout --orphan empty
 git rm -rf .
 git commit --allow-empty -m "Empty initial commit"
 
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "false" "Should handle empty repository state"
+assert_result 1 $result "$output" "" "Should handle empty repository state"
+
+# Test with stdout
+output=$(pr_changed_files --stdout)
+result=$?
+assert_result 0 $result "$output" "false" "Should handle empty repository state with --stdout"
 
 echo -e "\n✅ Edge cases tests passed"

--- a/tests/pr_changed_files/test_edge_cases.sh
+++ b/tests/pr_changed_files/test_edge_cases.sh
@@ -21,24 +21,24 @@ init_test_repo "$repo_path"
 unset BUILDKITE_PULL_REQUEST
 output=$(pr_changed_files 2>&1)
 result=$?
-assert_result 255 $result "$output" "Error: this tool can only be called from a Buildkite PR job" "Should fail when not in PR environment"
+assert_result 255 $result "Error: this tool can only be called from a Buildkite PR job" "$output" "Should fail when not in PR environment"
 
 export BUILDKITE_PULL_REQUEST="123"
 
 # [Test] No patterns provided
 output=$(pr_changed_files --any-match 2>&1)
 result=$?
-assert_result 255 $result "$output" "Error: must specify at least one file pattern" "Should fail when no patterns provided"
+assert_result 255 $result "Error: must specify at least one file pattern" "$output" "Should fail when no patterns provided"
 
 # [Test] Flag followed by another flag
 output=$(pr_changed_files --any-match --something 2>&1)
 result=$?
-assert_result 255 $result "$output" "Error: must specify at least one file pattern" "Should fail with correct error when flag is followed by another flag"
+assert_result 255 $result "Error: must specify at least one file pattern" "$output" "Should fail with correct error when flag is followed by another flag"
 
 # [Test] Mutually exclusive options
 output=$(pr_changed_files --any-match "*.txt" --all-match "*.md" 2>&1)
 result=$?
-assert_result 255 $result "$output" "Error: either specify --all-match or --any-match; cannot specify both" "Should fail with correct error when using mutually exclusive options"
+assert_result 255 $result "Error: either specify --all-match or --any-match; cannot specify both" "$output" "Should fail with correct error when using mutually exclusive options"
 
 # [Test] Files with spaces and special characters
 mkdir -p 'folder with spaces/nested!\@*#$folder'

--- a/tests/pr_changed_files/test_edge_cases.sh
+++ b/tests/pr_changed_files/test_edge_cases.sh
@@ -19,28 +19,26 @@ init_test_repo "$repo_path"
 
 # [Test] Invalid PR environment
 unset BUILDKITE_PULL_REQUEST
-pr_changed_files
+output=$(pr_changed_files 2>&1)
 result=$?
-assert_return_code 255 $result "Should fail when not in PR environment"
+assert_result 255 $result "$output" "Error: this tool can only be called from a Buildkite PR job" "Should fail when not in PR environment"
 
 export BUILDKITE_PULL_REQUEST="123"
 
 # [Test] No patterns provided
-pr_changed_files --any-match
+output=$(pr_changed_files --any-match 2>&1)
 result=$?
-assert_return_code 255 $result "Should fail when no patterns provided"
+assert_result 255 $result "$output" "Error: must specify at least one file pattern" "Should fail when no patterns provided"
 
 # [Test] Flag followed by another flag
 output=$(pr_changed_files --any-match --something 2>&1)
 result=$?
-assert_output "Error: must specify at least one file pattern" "$output" "Should fail with correct error when flag is followed by another flag"
-assert_return_code 255 $result "Should fail with correct error when flag is followed by another flag"
+assert_result 255 $result "$output" "Error: must specify at least one file pattern" "Should fail with correct error when flag is followed by another flag"
 
 # [Test] Mutually exclusive options
 output=$(pr_changed_files --any-match "*.txt" --all-match "*.md" 2>&1)
 result=$?
-assert_return_code 255 $result "Should fail with correct error when using mutually exclusive options"
-assert_output "Error: either specify --all-match or --any-match; cannot specify both" "$output" "Should fail with correct error when using mutually exclusive options"
+assert_result 255 $result "$output" "Error: either specify --all-match or --any-match; cannot specify both" "Should fail with correct error when using mutually exclusive options"
 
 # [Test] Files with spaces and special characters
 mkdir -p 'folder with spaces/nested!\@*#$folder'
@@ -49,39 +47,39 @@ echo "test" > 'folder with spaces/nested!\@*#$folder/file_with_!@*#$chars.txt'
 git add .
 git commit -m "Add files with special characters"
 
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 0 $result "Should handle files with spaces and special characters"
+assert_result 0 $result "$output" "true" "Should handle files with spaces and special characters"
 
 # [Test] Pattern matching with spaces and special characters
-pr_changed_files --any-match '*spaces.txt'
+output=$(pr_changed_files --any-match '*spaces.txt')
 result=$?
-assert_return_code 0 $result "Should match files with special characters in path"
+assert_result 0 $result "$output" "true" "Should match files with special characters in path"
 
-pr_changed_files --all-match 'folder with spaces/*'
+output=$(pr_changed_files --all-match 'folder with spaces/*')
 result=$?
-assert_return_code 0 $result "Should handle directory patterns with spaces"
+assert_result 0 $result "$output" "true" "Should handle directory patterns with spaces"
 
 # [Test] No changes between branches
 git checkout -b no_changes base
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 1 $result "Should handle no changes between branches"
+assert_result 1 $result "$output" "false" "Should handle no changes between branches"
 
 # [Test] Empty commit
 git checkout -b empty_commit base
 git commit --allow-empty -m "Empty commit"
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 1 $result "Should handle empty commit"
+assert_result 1 $result "$output" "false" "Should handle empty commit"
 
 # [Test] Empty repository state
 git checkout --orphan empty
 git rm -rf .
 git commit --allow-empty -m "Empty initial commit"
 
-pr_changed_files
+output=$(pr_changed_files)
 result=$?
-assert_return_code 1 $result "Should handle empty repository state"
+assert_result 1 $result "$output" "false" "Should handle empty repository state"
 
 echo -e "\n✅ Edge cases tests passed"

--- a/tests/pr_changed_files/test_edge_cases.sh
+++ b/tests/pr_changed_files/test_edge_cases.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -u
 
 set -o pipefail
 
@@ -19,25 +19,27 @@ init_test_repo "$repo_path"
 
 # [Test] Invalid PR environment
 unset BUILDKITE_PULL_REQUEST
-if pr_changed_files 2>/dev/null; then
-    echo "Should fail when not in PR environment"
-    exit 1
-fi
+pr_changed_files
+result=$?
+assert_return_code 255 $result "Should fail when not in PR environment"
 
 export BUILDKITE_PULL_REQUEST="123"
 
 # [Test] No patterns provided
-if pr_changed_files --any-match 2>/dev/null; then
-    echo "Should fail when no patterns provided"
-    exit 1
-fi
+pr_changed_files --any-match
+result=$?
+assert_return_code 255 $result "Should fail when no patterns provided"
 
 # [Test] Flag followed by another flag
-output=$(pr_changed_files --any-match --something 2>&1 || true)
+output=$(pr_changed_files --any-match --something 2>&1)
+result=$?
 assert_output "Error: must specify at least one file pattern" "$output" "Should fail with correct error when flag is followed by another flag"
+assert_return_code 255 $result "Should fail with correct error when flag is followed by another flag"
 
 # [Test] Mutually exclusive options
-output=$(pr_changed_files --any-match "*.txt" --all-match "*.md" 2>&1 || true)
+output=$(pr_changed_files --any-match "*.txt" --all-match "*.md" 2>&1)
+result=$?
+assert_return_code 255 $result "Should fail with correct error when using mutually exclusive options"
 assert_output "Error: either specify --all-match or --any-match; cannot specify both" "$output" "Should fail with correct error when using mutually exclusive options"
 
 # [Test] Files with spaces and special characters
@@ -47,33 +49,39 @@ echo "test" > 'folder with spaces/nested!\@*#$folder/file_with_!@*#$chars.txt'
 git add .
 git commit -m "Add files with special characters"
 
-result=$(pr_changed_files)
-assert_output "true" "$result" "Should handle files with spaces and special characters"
+pr_changed_files
+result=$?
+assert_return_code 0 $result "Should handle files with spaces and special characters"
 
 # [Test] Pattern matching with spaces and special characters
-result=$(pr_changed_files --any-match '*spaces.txt')
-assert_output "true" "$result" "Should match files with special characters in path"
+pr_changed_files --any-match '*spaces.txt'
+result=$?
+assert_return_code 0 $result "Should match files with special characters in path"
 
-result=$(pr_changed_files --all-match 'folder with spaces/*')
-assert_output "true" "$result" "Should handle directory patterns with spaces"
+pr_changed_files --all-match 'folder with spaces/*'
+result=$?
+assert_return_code 0 $result "Should handle directory patterns with spaces"
 
 # [Test] No changes between branches
 git checkout -b no_changes base
-result=$(pr_changed_files)
-assert_output "false" "$result" "Should handle no changes between branches"
+pr_changed_files
+result=$?
+assert_return_code 1 $result "Should handle no changes between branches"
 
 # [Test] Empty commit
 git checkout -b empty_commit base
 git commit --allow-empty -m "Empty commit"
-result=$(pr_changed_files)
-assert_output "false" "$result" "Should handle empty commit"
+pr_changed_files
+result=$?
+assert_return_code 1 $result "Should handle empty commit"
 
 # [Test] Empty repository state
 git checkout --orphan empty
 git rm -rf .
 git commit --allow-empty -m "Empty initial commit"
 
-result=$(pr_changed_files 2>/dev/null)
-assert_output "false" "$result" "Should handle empty repository state"
+pr_changed_files
+result=$?
+assert_return_code 1 $result "Should handle empty repository state"
 
 echo -e "\n✅ Edge cases tests passed"

--- a/tests/pr_changed_files/test_edge_cases.sh
+++ b/tests/pr_changed_files/test_edge_cases.sh
@@ -21,24 +21,24 @@ init_test_repo "$repo_path"
 unset BUILDKITE_PULL_REQUEST
 output=$(pr_changed_files 2>&1)
 result=$?
-assert_result 255 $result "Error: this tool can only be called from a Buildkite PR job" "$output" "Should fail when not in PR environment"
+assert_result $result 255 "$output" "Error: this tool can only be called from a Buildkite PR job" "Should fail when not in PR environment"
 
 export BUILDKITE_PULL_REQUEST="123"
 
 # [Test] No patterns provided
 output=$(pr_changed_files --any-match 2>&1)
 result=$?
-assert_result 255 $result "Error: must specify at least one file pattern" "$output" "Should fail when no patterns provided"
+assert_result $result 255 "$output" "Error: must specify at least one file pattern" "Should fail when no patterns provided"
 
 # [Test] Flag followed by another flag
 output=$(pr_changed_files --any-match --something 2>&1)
 result=$?
-assert_result 255 $result "Error: must specify at least one file pattern" "$output" "Should fail with correct error when flag is followed by another flag"
+assert_result $result 255 "$output" "Error: must specify at least one file pattern" "Should fail with correct error when flag is followed by another flag"
 
 # [Test] Mutually exclusive options
 output=$(pr_changed_files --any-match "*.txt" --all-match "*.md" 2>&1)
 result=$?
-assert_result 255 $result "Error: either specify --all-match or --any-match; cannot specify both" "$output" "Should fail with correct error when using mutually exclusive options"
+assert_result $result 255 "$output" "Error: either specify --all-match or --any-match; cannot specify both" "Should fail with correct error when using mutually exclusive options"
 
 # [Test] Files with spaces and special characters
 mkdir -p 'folder with spaces/nested!\@*#$folder'
@@ -50,45 +50,45 @@ git commit -m "Add files with special characters"
 # Test with exit code only
 output=$(pr_changed_files)
 result=$?
-assert_result 0 $result "$output" "" "Should handle files with spaces and special characters"
+assert_result $result 0 "$output" "" "Should handle files with spaces and special characters"
 
 # Test with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "true" "Should handle files with spaces and special characters with --stdout"
+assert_result $result 0 "$output" "true" "Should handle files with spaces and special characters with --stdout"
 
 # [Test] Pattern matching with spaces and special characters - exit code only
 output=$(pr_changed_files --any-match '*spaces.txt')
 result=$?
-assert_result 0 $result "$output" "" "Should match files with special characters in path"
+assert_result $result 0 "$output" "" "Should match files with special characters in path"
 
 # Test with stdout
 output=$(pr_changed_files --stdout --any-match '*spaces.txt')
 result=$?
-assert_result 0 $result "$output" "true" "Should match files with special characters in path with --stdout"
+assert_result $result 0 "$output" "true" "Should match files with special characters in path with --stdout"
 
 # [Test] No changes between branches - exit code only
 git checkout -b no_changes base
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "" "Should handle no changes between branches"
+assert_result $result 1 "$output" "" "Should handle no changes between branches"
 
 # Test with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "false" "Should handle no changes between branches with --stdout"
+assert_result $result 0 "$output" "false" "Should handle no changes between branches with --stdout"
 
 # [Test] Empty commit - exit code only
 git checkout -b empty_commit base
 git commit --allow-empty -m "Empty commit"
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "" "Should handle empty commit"
+assert_result $result 1 "$output" "" "Should handle empty commit"
 
 # Test with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "false" "Should handle empty commit with --stdout"
+assert_result $result 0 "$output" "false" "Should handle empty commit with --stdout"
 
 # [Test] Empty repository state - exit code only
 git checkout --orphan empty
@@ -97,11 +97,11 @@ git commit --allow-empty -m "Empty initial commit"
 
 output=$(pr_changed_files)
 result=$?
-assert_result 1 $result "$output" "" "Should handle empty repository state"
+assert_result $result 1 "$output" "" "Should handle empty repository state"
 
 # Test with stdout
 output=$(pr_changed_files --stdout)
 result=$?
-assert_result 0 $result "$output" "false" "Should handle empty repository state with --stdout"
+assert_result $result 0 "$output" "false" "Should handle empty repository state with --stdout"
 
 echo -e "\n✅ Edge cases tests passed"

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -65,14 +65,14 @@ cleanup_git_repo() {
 # Arguments:
 #   $1 - Expected return code
 #   $2 - Actual return code
-#   $3 - Actual output
-#   $4 - Expected output
+#   $3 - Expected output
+#   $4 - Actual output
 #   $5 - Optional message to display with the assertion result
 assert_result() {
     local expected_code="$1"
     local actual_code="$2"
-    local actual_output="$3"
-    local expected_output="$4"
+    local expected_output="$3"
+    local actual_output="$4"
     local message="$5"
 
     assert_equal "$expected_code" "$actual_code" "Exit code - $message"

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -75,8 +75,10 @@ assert_result() {
     local expected_output="$4"
     local message="$5"
 
-    assert_equal "$expected_code" "$actual_code" "$message"
-    assert_equal "$expected_output" "$actual_output" "$message"
+    assert_equal "$expected_code" "$actual_code" "Exit code - $message"
+    if [[ -n "$expected_output" ]]; then
+        assert_equal "$expected_output" "$actual_output" "Output - $message"
+    fi
 }
 
 # Helper function to assert that two values are equal

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -61,45 +61,40 @@ cleanup_git_repo() {
     rm -rf "$1"
 }
 
-# Helper to assert expected output
-assert_output() {
-    local expected="$1"
-    local actual="$2"
-    local message="${3:-}"
+# Helper to assert both return code and output
+# Arguments:
+#   $1 - Expected return code
+#   $2 - Actual return code
+#   $3 - Actual output
+#   $4 - Expected output
+#   $5 - Optional message to display with the assertion result
+assert_result() {
+    local expected_code="$1"
+    local actual_code="$2"
+    local actual_output="$3"
+    local expected_output="$4"
+    local message="$5"
 
-    if [[ "$actual" == "$expected" ]]; then
-        echo "🟢 Assertion succeeded: $message"
-    elif [[ "$actual" != "$expected" ]]; then
-        echo "❌ Assertion failed: $message"
-        echo "Expected: $expected"
-        echo "Actual  : $actual"
-        exit 1
-    fi
+    assert_equal "$expected_code" "$actual_code" "$message"
+    assert_equal "$expected_output" "$actual_output" "$message"
 }
 
-# Helper to assert expected return code
-assert_return_code() {
-    local expected="$1"
-    local actual="$2"
-    local message="${3:-}"
-
-    if [[ "$actual" == "$expected" ]]; then
-        echo "🟢 Return code assertion succeeded: $message"
-    else
-        echo "❌ Return code assertion failed: $message"
-        echo "Expected: $expected"
-        echo "Actual  : $actual"
-        exit 1
-    fi
-}
-
+# Helper function to assert that two values are equal
+# Arguments:
+#   $1 - Expected value
+#   $2 - Actual value 
+#   $3 - Optional message to display with the assertion result
 assert_equal() {
     local expected="$1"
     local actual="$2"
     local message="${3:-}"
-    
-    if [[ "$expected" != "$actual" ]]; then
-        echo "❌ Assertion failed: Expected '$expected' but got '$actual' ${message:+($message)}" >&2
-        return 1
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo "🟢 Assertion ('$actual') succeeded: $message"
+    elif [[ "$actual" != "$expected" ]]; then
+        echo "❌ Assertion failed ($actual != $expected): $message"
+        echo "Expected: $expected"
+        echo "Actual  : $actual"
+        exit 1
     fi
 }

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -63,21 +63,21 @@ cleanup_git_repo() {
 
 # Helper to assert both return code and output
 # Arguments:
-#   $1 - Expected return code
-#   $2 - Actual return code
-#   $3 - Expected output
-#   $4 - Actual output
+#   $1 - Actual return code
+#   $2 - Expected return code
+#   $3 - Actual output
+#   $4 - Expected output
 #   $5 - Optional message to display with the assertion result
 assert_result() {
-    local expected_code="$1"
-    local actual_code="$2"
-    local expected_output="$3"
-    local actual_output="$4"
+    local actual_code="$1"
+    local expected_code="$2"
+    local actual_output="$3"
+    local expected_output="$4"
     local message="$5"
 
-    assert_equal "$expected_code" "$actual_code" "Exit code - $message"
+    assert_equal "$actual_code" "$expected_code" "Exit code - $message"
     if [[ -n "$expected_output" ]]; then
-        assert_equal "$expected_output" "$actual_output" "Output - $message"
+        assert_equal "$actual_output" "$expected_output" "Output - $message"
     fi
 }
 
@@ -87,8 +87,8 @@ assert_result() {
 #   $2 - Actual value 
 #   $3 - Optional message to display with the assertion result
 assert_equal() {
-    local expected="$1"
-    local actual="$2"
+    local actual="$1"
+    local expected="$2"
     local message="${3:-}"
 
     if [[ "$actual" == "$expected" ]]; then

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -92,3 +92,14 @@ assert_return_code() {
         exit 1
     fi
 }
+
+assert_equal() {
+    local expected="$1"
+    local actual="$2"
+    local message="${3:-}"
+    
+    if [[ "$expected" != "$actual" ]]; then
+        echo "❌ Assertion failed: Expected '$expected' but got '$actual' ${message:+($message)}" >&2
+        return 1
+    fi
+}

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -76,3 +76,19 @@ assert_output() {
         exit 1
     fi
 }
+
+# Helper to assert expected return code
+assert_return_code() {
+    local expected="$1"
+    local actual="$2"
+    local message="${3:-}"
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo "🟢 Return code assertion succeeded: $message"
+    else
+        echo "❌ Return code assertion failed: $message"
+        echo "Expected: $expected"
+        echo "Actual  : $actual"
+        exit 1
+    fi
+}

--- a/tests/pr_changed_files/test_helpers.sh
+++ b/tests/pr_changed_files/test_helpers.sh
@@ -76,9 +76,7 @@ assert_result() {
     local message="$5"
 
     assert_equal "$actual_code" "$expected_code" "Exit code - $message"
-    if [[ -n "$expected_output" ]]; then
-        assert_equal "$actual_output" "$expected_output" "Output - $message"
-    fi
+    assert_equal "$actual_output" "$expected_output" "Output - $message"
 }
 
 # Helper function to assert that two values are equal


### PR DESCRIPTION
Follow up to the discussion started on https://github.com/woocommerce/woocommerce-ios/pull/15086#discussion_r1953247300.

This PR adds both exit codes (default mode) and `"true"` `"false"` output (using `--stdout` flag) to the `pr_changed_files` command, updating documentation and tests accordingly.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
