### PR TITLE
Windows 10 SDK install tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -121,19 +121,19 @@ steps:
 
   - group: ":windows: install_windows_10_sdk Tests"
     steps:
-      - label: ":windows: install_windows_10_sdk Tests - Standard version file"
+      - label: ":windows: install_windows_10_sdk Tests - Version file with valid format and version"
         command: |
-          "123" | Out-File .windows-10-sdk-version
+          "20348" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
         notify:
           - github_commit_status:
-              context: "install_windows_10_sdk Tests - Standard version file"
+              context: "install_windows_10_sdk Tests - Version file with valid format and version"
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with one new line"
         command: |
-          "123`n" | Out-File .windows-10-sdk-version
+          "20348`n" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -143,7 +143,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with more than one new line"
         command: |
-          "123`n`n" | Out-File .windows-10-sdk-version
+          "20348`n`n" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -153,7 +153,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with leading whitespaces"
         command: |
-          "  123" | Out-File .windows-10-sdk-version
+          "  19041" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -163,7 +163,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with trailing whitespaces"
         command: |
-          "123   " | Out-File .windows-10-sdk-version
+          "18362   " | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -193,3 +193,15 @@ steps:
         notify:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with a word"
+
+      - label: ":windows: install_windows_10_sdk Tests - Version file with version number that is not in the allowed list"
+        command: |
+          "12345" | Out-File .windows-10-sdk-version
+          .\tests\test-install-windows-10-sdk.ps1 `
+            -ExpectedExitCode 1 `
+            -ExpectedErrorKeyphrase "Invalid Windows 10 SDK version: 12345"
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with version number that is not in the allowed list"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -151,6 +151,16 @@ steps:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with more than one new line"
 
+      - label: ":windows: install_windows_10_sdk Tests - Version file with trailing whitespace"
+        command: |
+          "123   " | Out-File .windows-10-sdk-version
+          .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with trailing whitespace"
+
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
           "not an integer" | Out-File .windows-10-sdk-version

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -151,7 +151,17 @@ steps:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with more than one new line"
 
-      - label: ":windows: install_windows_10_sdk Tests - Version file with trailing whitespace"
+      - label: ":windows: install_windows_10_sdk Tests - Version file with leading whitespaces"
+        command: |
+          "  123" | Out-File .windows-10-sdk-version
+          .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with leading whitespaces"
+
+      - label: ":windows: install_windows_10_sdk Tests - Version file with trailing whitespaces"
         command: |
           "123   " | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
@@ -159,7 +169,7 @@ steps:
           queue: windows
         notify:
           - github_commit_status:
-              context: "install_windows_10_sdk Tests - Version file with trailing whitespace"
+              context: "install_windows_10_sdk Tests - Version file with trailing whitespaces"
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -140,3 +140,13 @@ steps:
         notify:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with new lines"
+
+      - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
+        command: |
+          echo "not an integer" > .windows-10-sdk-version
+          bin/install_windows_10_sdk.ps1
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with a word"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -134,9 +134,7 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with one new line"
         command: |
           "123`n" | Out-File .windows-10-sdk-version
-          .\tests\test-install-windows-10-sdk.ps1 `
-            -ExpectedExitCode 1 `
-            -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
+          .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
         notify:
@@ -146,9 +144,7 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with more than one new line"
         command: |
           "123`n`n" | Out-File .windows-10-sdk-version
-          .\tests\test-install-windows-10-sdk.ps1 `
-            -ExpectedExitCode 1 `
-            -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
+          .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,3 +118,25 @@ steps:
         notify:
           - github_commit_status:
               context: "pr_changed_files Tests: Edge Cases"
+
+  - group: ":windows: install_windows_10_sdk Tests"
+    steps:
+      - label: ":windows: install_windows_10_sdk Tests - Standard version file"
+        command: |
+          echo '20348' > .windows-10-sdk-version
+          bin/install_windows_10_sdk.ps1
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Standard version file"
+
+      - label: ":windows: install_windows_10_sdk Tests - Version file with new lines"
+        command: |
+          echo "20348\n\n" > .windows-10-sdk-version
+          bin/install_windows_10_sdk.ps1
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with new lines"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,7 +124,14 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Standard version file"
         command: |
           echo '20348' > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1 -DryRun
+          $output = & bin/install_windows_10_sdk.ps1 -DryRun
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) {
+            echo "Unexpected failure. Exit code: $exitCode"
+            echo "Output:"
+            echo $output
+            exit 1
+          }
         agents:
           queue: windows
         notify:
@@ -133,8 +140,19 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with new lines"
         command: |
-          echo "20348\n\n" > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1 -DryRun
+          echo "20348`n`n" > .windows-10-sdk-version
+          $output = & bin/install_windows_10_sdk.ps1 -DryRun
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 0) {
+            echo "Unexpected failure. Exit code: $exitCode"
+            echo "Output:"
+            echo $output
+            exit 1
+          }
+          if (($output -notmatch "[!] Invalid version file format") -and ($output -notmatch "Expected exactly one non-empty line")) {
+            echo "Failure message did not match expectation."
+            exit 1
+          }
         agents:
           queue: windows
         notify:
@@ -144,7 +162,18 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
           echo "not an integer" > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1 -DryRun
+          $output = & bin/install_windows_10_sdk.ps1 -DryRun
+          $exitCode = $LASTEXITCODE
+          if ($exitCode -ne 1) {
+            echo "Expected exit code 1, got: $exitCode"
+            echo "Output:"
+            echo $output
+            exit 1
+          }
+          if (($output -notmatch "[!] Invalid version file format") -and ($output -notmatch "Expected an integer, got:'")) {
+            echo "Failure message did not match expectation."
+            exit 1
+          }
         agents:
           queue: windows
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,15 +122,18 @@ steps:
   - group: ":windows: install_windows_10_sdk Tests"
     steps:
       - label: ":windows: install_windows_10_sdk Tests - Standard version file"
-        command: .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
+        command: |
+          echo '20348' > .windows-10-sdk-version
+          .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
         notify:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Standard version file"
 
-      - label: ":windows: install_windows_10_sdk Tests - Version file with new lines"
+      - label: ":windows: install_windows_10_sdk Tests - Version file with one new line"
         command: |
+          echo "20348\n" > .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
             -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
@@ -138,10 +141,23 @@ steps:
           queue: windows
         notify:
           - github_commit_status:
-              context: "install_windows_10_sdk Tests - Version file with new lines"
+              context: "install_windows_10_sdk Tests - Version file with one new line"
+
+      - label: ":windows: install_windows_10_sdk Tests - Version file with more than one new line"
+        command: |
+          echo "20348\n\n" > .windows-10-sdk-version
+          .\tests\test-install-windows-10-sdk.ps1 `
+            -ExpectedExitCode 1 `
+            -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with more than one new line"
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
+          echo 'not an integer' > .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
             -ExpectedErrorKeyphrase "Expected version to be an integer"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -160,7 +160,7 @@ steps:
           echo 'not an integer' > .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
-            -ExpectedErrorKeyphrase "Expected version to be an integer"
+            -ExpectedErrorKeyphrase "Expected an integer"
         agents:
           queue: windows
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,7 +123,7 @@ steps:
     steps:
       - label: ":windows: install_windows_10_sdk Tests - Standard version file"
         command: |
-          echo '20348' > .windows-10-sdk-version
+          "123" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -133,7 +133,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with one new line"
         command: |
-          echo "20348\n" > .windows-10-sdk-version
+          "123`n" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
             -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
@@ -145,7 +145,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with more than one new line"
         command: |
-          echo "20348\n\n" > .windows-10-sdk-version
+          "123`n`n" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
             -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
@@ -157,7 +157,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
-          echo 'not an integer' > .windows-10-sdk-version
+          "not an integer" | Out-File .windows-10-sdk-version
           .\tests\test-install-windows-10-sdk.ps1 `
             -ExpectedExitCode 1 `
             -ExpectedErrorKeyphrase "Expected an integer"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -205,3 +205,11 @@ steps:
         notify:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with version number that is not in the allowed list"
+
+  - label: ":windows: prepare_windows_host_for_app_distribution Tests - Skip Windows 10 SDK Installation"
+    command: .\tests\test-prepare-windows-host-for-app-distribution.ps1
+    agents:
+      queue: windows
+    notify:
+      - github_commit_status:
+          context: "prepare_windows_host_for_app_distribution Tests - Skip Windows 10 SDK Installation"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,7 +124,7 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Standard version file"
         command: |
           echo '20348' > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1
+          bin/install_windows_10_sdk.ps1 -DryRun
         agents:
           queue: windows
         notify:
@@ -134,7 +134,7 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with new lines"
         command: |
           echo "20348\n\n" > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1
+          bin/install_windows_10_sdk.ps1 -DryRun
         agents:
           queue: windows
         notify:
@@ -144,7 +144,7 @@ steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
           echo "not an integer" > .windows-10-sdk-version
-          bin/install_windows_10_sdk.ps1
+          bin/install_windows_10_sdk.ps1 -DryRun
         agents:
           queue: windows
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,16 +122,7 @@ steps:
   - group: ":windows: install_windows_10_sdk Tests"
     steps:
       - label: ":windows: install_windows_10_sdk Tests - Standard version file"
-        command: |
-          echo '20348' > .windows-10-sdk-version
-          $output = & bin/install_windows_10_sdk.ps1 -DryRun
-          $exitCode = $LASTEXITCODE
-          if ($exitCode -ne 0) {
-            echo "Unexpected failure. Exit code: $exitCode"
-            echo "Output:"
-            echo $output
-            exit 1
-          }
+        command: .\tests\test-install-windows-10-sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
         notify:
@@ -140,19 +131,9 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with new lines"
         command: |
-          echo "20348`n`n" > .windows-10-sdk-version
-          $output = & bin/install_windows_10_sdk.ps1 -DryRun
-          $exitCode = $LASTEXITCODE
-          if ($exitCode -ne 0) {
-            echo "Unexpected failure. Exit code: $exitCode"
-            echo "Output:"
-            echo $output
-            exit 1
-          }
-          if (($output -notmatch "[!] Invalid version file format") -and ($output -notmatch "Expected exactly one non-empty line")) {
-            echo "Failure message did not match expectation."
-            exit 1
-          }
+          .\tests\test-install-windows-10-sdk.ps1 `
+            -ExpectedExitCode 1 `
+            -ExpectedErrorKeyphrase "Expected exactly one non-empty line"
         agents:
           queue: windows
         notify:
@@ -161,19 +142,20 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with a word"
         command: |
-          echo "not an integer" > .windows-10-sdk-version
-          $output = & bin/install_windows_10_sdk.ps1 -DryRun
-          $exitCode = $LASTEXITCODE
-          if ($exitCode -ne 1) {
-            echo "Expected exit code 1, got: $exitCode"
-            echo "Output:"
-            echo $output
-            exit 1
-          }
-          if (($output -notmatch "[!] Invalid version file format") -and ($output -notmatch "Expected an integer, got:'")) {
-            echo "Failure message did not match expectation."
-            exit 1
-          }
+          .\tests\test-install-windows-10-sdk.ps1 `
+            -ExpectedExitCode 1 `
+            -ExpectedErrorKeyphrase "Expected version to be an integer"
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_windows_10_sdk Tests - Version file with a word"
+
+      - label: ":windows: install_windows_10_sdk Tests - Missing version file"
+        command: |
+          .\tests\test-install-windows-10-sdk.ps1 `
+            -ExpectedExitCode 1 `
+            -ExpectedErrorKeyphrase "No Windows 10 SDK version file found at .windows-10-sdk-version"
         agents:
           queue: windows
         notify:

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -13,8 +13,7 @@ if (-not (Test-Path $windowsSDKVersionFile)) {
   exit 1
 }
 
-$windows10SDKVersion = Get-Content $windowsSDKVersionFile `
-  | Where-Object { $_ -match '\S' }  # Remove empty lines
+$windows10SDKVersion = (Get-Content -TotalCount 1 $windowsSDKVersionFile).Trim()
 
 if ($windows10SDKVersion.Count -ne 1) {
   Write-Output "[!] Invalid version file format."

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -1,4 +1,4 @@
-param ( # parameters need to be defined at the top of the script
+param (
   [switch]$DryRun = $false
 )
 

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -5,7 +5,7 @@ param ( # parameters need to be defined at the top of the script
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-Write-Host "--- :windows: Installing Windows 10 SDK and Visual Studio Build Tools"
+Write-Output "--- :windows: Installing Windows 10 SDK and Visual Studio Build Tools"
 
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (-not (Test-Path $windowsSDKVersionFile)) {

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -9,6 +9,18 @@ $ErrorActionPreference = "Stop"
 
 Write-Output "--- :windows: Installing Windows 10 SDK and Visual Studio Build Tools"
 
+# See list at https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+$allowedVersions = @(
+  "20348",
+  "19041",
+  "18362",
+  "17763",
+  "17134",
+  "16299",
+  "15063",
+  "14393"
+)
+
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (-not (Test-Path $windowsSDKVersionFile)) {
   Write-Output "[!] No Windows 10 SDK version file found at $windowsSDKVersionFile."
@@ -20,6 +32,16 @@ $windows10SDKVersion = (Get-Content -TotalCount 1 $windowsSDKVersionFile).Trim()
 if ($windows10SDKVersion -notmatch '^\d+$') {
   Write-Output "[!] Invalid version file format."
   Write-Output "Expected an integer, got: '$windows10SDKVersion'"
+  exit 1
+}
+
+if ($allowedVersions -notcontains $windows10SDKVersion) {
+  Write-Output "[!] Invalid Windows 10 SDK version: $windows10SDKVersion"
+  Write-Output "Allowed versions are:"
+  foreach ($version in $allowedVersions) {
+    Write-Output "- $version"
+  }
+  Write-Output "More info at https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022"
   exit 1
 }
 

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -24,7 +24,7 @@ if ($windows10SDKVersion.Count -ne 1) {
 }
 
 if ($windows10SDKVersion -notmatch '^\d+$') {
-  Write-Output "[!] Invalid version format."
+  Write-Output "[!] Invalid version file format."
   Write-Output "Expected an integer, got: '$windows10SDKVersion'"
   exit 1
 }
@@ -49,7 +49,7 @@ If (-not (Test-Path $buildToolsPath)) {
   Write-Output "[!] Failed to download Visual Studio Build Tools"
   Exit 1
 } else {
-  Write-Output "Successfully downloaded Visual Studio Build Toosl at $buildToolsPath."
+  Write-Output "Successfully downloaded Visual Studio Build Tools at $buildToolsPath."
 }
 
 # Install the Windows SDK and other required components

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -9,7 +9,21 @@ if (-not (Test-Path $windowsSDKVersionFile)) {
   exit 1
 }
 
-$windows10SDKVersion = Get-Content $windowsSDKVersionFile
+$windows10SDKVersion = Get-Content $windowsSDKVersionFile `
+  | Where-Object { $_ -match '\S' }  # Remove empty lines
+
+if ($windows10SDKVersion.Count -ne 1) {
+  Write-Output "[!] Invalid version file format."
+  Write-Output "Expected exactly one non-empty line, got:"
+  Write-Output ($windows10SDKVersion -join "`n")  # The join poperly formats multiple lines
+  exit 1
+}
+
+if ($windows10SDKVersion -notmatch '^\d+$') {
+  Write-Output "[!] Invalid version format."
+  Write-Output "Expected an integer, got: '$windows10SDKVersion'"
+  exit 1
+}
 
 Write-Host "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
 

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -1,4 +1,12 @@
-# Install the Windows 10 SDK and Visual Studio Build Tools.
+# Install the Windows 10 SDK and Visual Studio Build Tools using the value in .windows-10-sdk-version.
+#
+# The expected .windows-10-sdk-version format is a integer representing a valid SDK component id.
+# The list of valid component ids can be found at
+# https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+#
+# Example:
+#
+#   20348
 
 param (
   [switch]$DryRun = $false

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -45,7 +45,7 @@ if ($allowedVersions -notcontains $windows10SDKVersion) {
   exit 1
 }
 
-Write-Host "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
+Write-Output "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
 
 if ($DryRun) {
   Write-Output "Running in dry run mode, finishing here."

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -1,3 +1,7 @@
+param ( # parameters need to be defined at the top of the script
+  [switch]$DryRun = $false
+)
+
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
@@ -26,6 +30,11 @@ if ($windows10SDKVersion -notmatch '^\d+$') {
 }
 
 Write-Host "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
+
+if ($DryRun) {
+  Write-Output "Running in dry run mode, finishing here."
+  exit 0
+}
 
 # Download the Visual Studio Build Tools Bootstrapper
 Write-Output "~~~ Downloading Visual Studio Build Tools..."

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -15,13 +15,6 @@ if (-not (Test-Path $windowsSDKVersionFile)) {
 
 $windows10SDKVersion = (Get-Content -TotalCount 1 $windowsSDKVersionFile).Trim()
 
-if ($windows10SDKVersion.Count -ne 1) {
-  Write-Output "[!] Invalid version file format."
-  Write-Output "Expected exactly one non-empty line, got:"
-  Write-Output ($windows10SDKVersion -join "`n")  # The join poperly formats multiple lines
-  exit 1
-}
-
 if ($windows10SDKVersion -notmatch '^\d+$') {
   Write-Output "[!] Invalid version file format."
   Write-Output "Expected an integer, got: '$windows10SDKVersion'"

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -1,3 +1,5 @@
+# Install the Windows 10 SDK and Visual Studio Build Tools.
+
 param (
   [switch]$DryRun = $false
 )

--- a/bin/path_aware_refreshenv.ps1
+++ b/bin/path_aware_refreshenv.ps1
@@ -16,10 +16,10 @@
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-Write-Host "PATH before refreshenv is $env:PATH"
+Write-Output "PATH before refreshenv is $env:PATH"
 $originalPath = "$env:PATH"
-Write-Host "Calling refreshenv..."
+Write-Output "Calling refreshenv..."
 refreshenv
 $mergedPath = "$env:PATH;$originalPath" -split ";" | Select-Object -Unique -Skip 1
 $env:PATH = ($mergedPath -join ";")
-Write-Host "PATH after refreshenv is $env:PATH"
+Write-Output "PATH after refreshenv is $env:PATH"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -20,16 +20,16 @@ param (
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
-Write-Host "--- :windows: Setting up Windows for app distribution"
+Write-Output "--- :windows: Setting up Windows for app distribution"
 
-Write-Host "Current working directory: $PWD"
+Write-Output "Current working directory: $PWD"
 
-Write-Host "Enable long path behavior"
+Write-Output "Enable long path behavior"
 # See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
 Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1
 
 # Disable Windows Defender before starting – otherwise our performance is terrible
-Write-Host "Disable Windows Defender..."
+Write-Output "Disable Windows Defender..."
 $avPreference = @(
     @{DisableArchiveScanning = $true}
     @{DisableAutoExclusions = $true}
@@ -65,12 +65,12 @@ $avPreference | Foreach-Object {
 # https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/microsoft-defender-antivirus-compatibility?view=o365-worldwide
 $atpRegPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows Advanced Threat Protection'
 if (Test-Path $atpRegPath) {
-    Write-Host "Set Microsoft Defender Antivirus to passive mode"
+    Write-Output "Set Microsoft Defender Antivirus to passive mode"
     Set-ItemProperty -Path $atpRegPath -Name 'ForceDefenderPassiveMode' -Value '1' -Type 'DWORD'
 }
 
 # From https://stackoverflow.com/a/46760714
-Write-Host "--- :windows: Setting up Package Manager"
+Write-Output "--- :windows: Setting up Package Manager"
 $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 
@@ -78,46 +78,46 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 #
 # See how this build failed
 # https://buildkite.com/automattic/beeper-desktop/builds/2895#01919738-7c6e-4b82-8d1d-1c1800481740
-Write-Host "--- :windows: :linux: Enable developer mode to use symlinks"
+Write-Output "--- :windows: :linux: Enable developer mode to use symlinks"
 
 $developerMode = Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
 
 if ($developerMode.State -eq 'Enabled') {
-    Write-Host "Developer Mode is already enabled."
+    Write-Output "Developer Mode is already enabled."
 } else {
-    Write-Host "Enabling Developer Mode..."
+    Write-Output "Enabling Developer Mode..."
     try {
       Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart
     } catch {
-      Write-Host "Failed to enable Developer Mode. Continuing without it..."
+      Write-Output "Failed to enable Developer Mode. Continuing without it..."
     }
 }
 
-Write-Host "--- :lock_with_ink_pen: Download Code Signing Certificate"
+Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
 $certificateBinPath = "certificate.bin"
 $EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
   | jq -r '.SecretString' `
   | Out-File $certificateBinPath
 $certificatePfxPath = "certificate.pfx"
 certutil -decode $certificateBinPath $certificatePfxPath
-Write-Host "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
+Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
 
-Write-Host "--- :windows: Checking whether to install Windows 10 SDK..."
+Write-Output "--- :windows: Checking whether to install Windows 10 SDK..."
 
 # When using Electron Forge and electron2appx, building Appx requires the Windows 10 SDK
 #
 # See https://github.com/hermit99/electron-windows-store/tree/v2.1.2?tab=readme-ov-file#usage
 
 if ($SkipWindows10SDKInstallation) {
-    Write-Host "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+    Write-Output "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
     exit 0
 }
 
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (Test-Path $windowsSDKVersionFile) {
-    Write-Host "Found $windowsSDKVersionFile file, installing Windows 10 SDK..."
+    Write-Output "Found $windowsSDKVersionFile file, installing Windows 10 SDK..."
     & "$PSScriptRoot\install_windows_10_sdk.ps1"
     If ($LastExitCode -ne 0) { Exit $LastExitCode }
 } else {
-    Write-Host "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."
+    Write-Output "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."
 }

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -8,10 +8,14 @@
 #  - Install the Windows 10 SDK if it detected a `.windows-10-sdk-version` file(2)
 #
 # (1) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
-# (2) You can skip the Win10 install even if `.windows-10-sdk-version` file is present by using the `SKIP_WINDOWS_10_SDK_INSTALL=1` env var before calling this script
+# (2) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
 #
 # Note: In addition to calling this script, and depending on your client app, you might want to also install `npm` and the `Node.js` packages used by your client app on the agent too. For that part, you should use the `automattic/nvm` Buildkite plugin on the pipeline step's `plugins:` attribute.
 #
+
+param (
+  [switch]$SkipWindows10SDKInstallation = $false
+)
 
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
@@ -103,6 +107,11 @@ Write-Host "--- :windows: Checking whether to install Windows 10 SDK..."
 # When using Electron Forge and electron2appx, building Appx requires the Windows 10 SDK
 #
 # See https://github.com/hermit99/electron-windows-store/tree/v2.1.2?tab=readme-ov-file#usage
+
+if ($SkipWindows10SDKInstallation) {
+    Write-Host "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+    exit 0
+}
 
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (Test-Path $windowsSDKVersionFile) {

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -5,10 +5,13 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+$emojiGreenCheck = "$([char]0x2705)"
+$emojiRedCross = "$([char]0x274C)"
+
 Write-Output "Running test-install-windows-10-sdk.ps1 with ExpectedExitCode=$ExpectedExitCode and ExpectedErrorKeyphrase=$ExpectedErrorKeyphrase"
 
 if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
-  Write-Output "Expected call to succeed, but given an error keyphrase to check."
+  Write-Output "$emojiRedCross Expected call to succeed (expected error code = 0), but given an error keyphrase to check."
   exit 1
 }
 
@@ -16,12 +19,12 @@ $output = & "$PSScriptRoot\..\bin\install_windows_10_sdk.ps1" -DryRun
 $exitCode = $LASTEXITCODE
 
 if ($exitCode -ne $ExpectedExitCode) {
-  Write-Output "Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
   Write-Output "Output was:"
   Write-Output "$output"
   exit 1
 } else {
-  Write-Output "✅ Exit code matches expected value ($ExpectedExitCode)"
+  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
 }
 
 # Only check error keyphrase if exit code is not 0
@@ -36,10 +39,10 @@ if ($ExpectedErrorKeyphrase -eq "") {
 }
 
 if ($output -notmatch $ExpectedErrorKeyphrase) {
-  Write-Output "Expected error to contain '$ExpectedErrorKeyphrase', but got:"
+  Write-Output "$emojiRedCross Expected error to contain '$ExpectedErrorKeyphrase', but got:"
   Write-Output "$output"
   exit 1
 } else {
-  Write-Output "✅ Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
+  Write-Output "$emojiGreenCheck Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
   Write-Output "Test completed."
 }

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -5,17 +5,23 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+Write-Output "Running test-install-windows-10-sdk.ps1 with ExpectedExitCode=$ExpectedExitCode and ExpectedErrorKeyphrase=$ExpectedErrorKeyphrase"
+
 if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
-  Write-Error "Expected call to succeed, but given an error keyphrase to check."
+  Write-Output "Expected call to succeed, but given an error keyphrase to check."
   exit 1
 }
 
-$output = "$PSScriptRoot\..\bin\install_windows_10_sdk.ps1 -DryRun"
+$output = & "$PSScriptRoot\..\bin\install_windows_10_sdk.ps1" -DryRun
 $exitCode = $LASTEXITCODE
 
 if ($exitCode -ne $ExpectedExitCode) {
-  Write-Error "Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
   exit 1
+} else {
+  Write-Output "✅ Exit code matches expected value ($ExpectedExitCode)"
 }
 
 # Only check error keyphrase if exit code is not 0
@@ -23,8 +29,17 @@ if ($exitCode -eq 0) {
   exit 0
 }
 
+# If keyphrase is empty, assume the caller is satisfied with only testing the exit code
+if ($ExpectedErrorKeyphrase -eq "") {
+  Write-Output "Exit code match expectation and no error keyphrase was provided. Test completed."
+  exit 0
+}
+
 if ($output -notmatch $ExpectedErrorKeyphrase) {
-  Write-Error "Expected error to contain '$ExpectedErrorKeyphrase', but got:"
-  Write-Error "$output"
+  Write-Output "Expected error to contain '$ExpectedErrorKeyphrase', but got:"
+  Write-Output "$output"
   exit 1
+} else {
+  Write-Output "✅ Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
+  Write-Output "Test completed."
 }

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -3,8 +3,6 @@ param (
   [string]$ExpectedErrorKeyphrase = ""
 )
 
-$ErrorActionPreference = "Stop"
-
 # Ensure the output is UTF-8 encoded so we can use emojis...
 [System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $emojiGreenCheck = "$([char]0x2705)"

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -1,0 +1,30 @@
+param (
+  [int]$ExpectedExitCode = 0,
+  [string]$ExpectedErrorKeyphrase = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
+  Write-Error "Expected call to succeed, but given an error keyphrase to check."
+  exit 1
+}
+
+$output = "$PSScriptRoot\..\bin\install_windows_10_sdk.ps1 -DryRun"
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Error "Expected exit code $ExpectedExitCode, got $exitCode"
+  exit 1
+}
+
+# Only check error keyphrase if exit code is not 0
+if ($exitCode -eq 0) {
+  exit 0
+}
+
+if ($output -notmatch $ExpectedErrorKeyphrase) {
+  Write-Error "Expected error to contain '$ExpectedErrorKeyphrase', but got:"
+  Write-Error "$output"
+  exit 1
+}

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -38,11 +38,11 @@ if ($ExpectedErrorKeyphrase -eq "") {
   exit 0
 }
 
-if ($output -notmatch $ExpectedErrorKeyphrase) {
+if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
+  Write-Output "$emojiGreenCheck Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
+  Write-Output "Test completed."
+} else {
   Write-Output "$emojiRedCross Expected error to contain '$ExpectedErrorKeyphrase', but got:"
   Write-Output "$output"
   exit 1
-} else {
-  Write-Output "$emojiGreenCheck Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
-  Write-Output "Test completed."
 }

--- a/tests/test-install-windows-10-sdk.ps1
+++ b/tests/test-install-windows-10-sdk.ps1
@@ -5,6 +5,8 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+# Ensure the output is UTF-8 encoded so we can use emojis...
+[System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $emojiGreenCheck = "$([char]0x2705)"
 $emojiRedCross = "$([char]0x274C)"
 

--- a/tests/test-prepare-windows-host-for-app-distribution.ps1
+++ b/tests/test-prepare-windows-host-for-app-distribution.ps1
@@ -1,0 +1,53 @@
+# Tests the prepare_windows_host_for_app_distribution.ps1 script with the -SkipWindows10SDKInstallation parameter.
+#
+# We only test the skip behavior because the installation takes a "long" time to run.
+
+param (
+  [int]$ExpectedExitCode = 0
+)
+
+# Ensure the output is UTF-8 encoded so we can use emojis...
+[System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$emojiGreenCheck = "$([char]0x2705)"
+$emojiRedCross = "$([char]0x274C)"
+
+Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with -SkipWindows10SDKInstallation"
+
+# Create a valid SDK version file to ensure it's not being used
+$sdkVersion = "20348"
+"$sdkVersion" | Out-File .windows-10-sdk-version
+
+# Run the script with skip parameter
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation
+$exitCode = $LASTEXITCODE
+
+# Check exit code
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
+  exit 1
+} else {
+  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
+}
+
+$expectedSkipMessage = "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+if ($output -match [regex]::Escape($expectedSkipMessage)) {
+  Write-Output "$emojiGreenCheck Found expected skip message in output"
+} else {
+  Write-Output "$emojiRedCross Expected to find message about skipping due to parameter, but got:"
+  Write-Output "$output"
+  exit 1
+}
+
+# Verify SDK was not installed by checking the file system
+$windowsSDKsRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
+$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion\x64"
+If (Test-Path $sdkPath) {
+  Write-Output "$emojiRedCross Found SDK installation at $sdkPath when it should have been skipped"
+  exit 1
+} else {
+  Write-Output "$emojiGreenCheck Confirmed SDK was not installed at $sdkPath"
+}
+
+Write-Output "Test completed successfully."


### PR DESCRIPTION
Builds on top of #144. Initially, this was a dedicated PR because I expected a lot of Git noise by trial and error in CI. But as I kept refining the implementation for the Windows 10 SDK version file validation, I also introduced what I hope are other improvements to the Windows scripts.

- Adds validation of the `.windows-10-sdk-version` content before attempting to use said content as the version to install, including comparing against an allow-list of valid versions
- Replaces all `Write-Host` with `Write-Output`, because `Write-Host` is meant for messages such as user prompts
- Adds a `-DryRun` option to the Windows 10 SDK install script, mostly so it can be tested without doing a full install
- Adds a `SkipWindows10SDKInstallation` to the host setup script, just in case

Together with #144, I think this should be enough for now to ship a new plugin (major) version and begin DRYing the Electron apps.

## Next steps

- Take a look at the CI setup time and consider moving the tests into a single script if the overhead is considerable
- Keep working on #133 to make sure the script properly handle errors

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.
