### PR TITLE
Fail early if AWS CLI is missing on not configured

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,7 +158,9 @@ steps:
         command: |
           echo "~~~ :hammer: Remove AWS credentials"
           set -x
-          # Removing ~/.aws does not work and neither does clearing the AWS CLI env vars
+          rm -rf ~/.aws
+          unset AWS_ACCESS_KEY_ID
+          unset AWS_SECRET_ACCESS_KEY
           aws configure set aws_access_key_id ""
           aws configure set aws_secret_access_key ""
           set +x

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,3 +129,23 @@ steps:
     notify:
       - github_commit_status:
           context: "verify_aws_cli_setup Test succeeds when AWS CLI setup"
+
+  - label: ":aws: verify_aws_cli_setup Test fails when missing AWS"
+    agents:
+      queue: default
+    plugins:
+      # Alpine shouldn't have AWS CLI installed, so this should fail
+      - docker#v5.7.0:
+          image: "alpine:latest"
+          propagate-exit-status: false
+    command: |
+      echo "--- :microscope: Run verify_aws_cli_setup"
+      if bin/verify_aws_cli_setup; then
+        echo "Error: Script succeeded but should have failed (AWS CLI not present in container)"
+        exit 1
+      else
+        echo "Success: Script failed as expected when AWS CLI not present"
+      fi
+    notify:
+      - github_commit_status:
+          context: "verify_aws_cli_setup Test fails when missing AWS"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -149,3 +149,24 @@ steps:
     notify:
       - github_commit_status:
           context: "verify_aws_cli_setup Test fails when missing AWS"
+
+  - label: ":aws: verify_aws_cli_setup Test fails when missing AWS credentials"
+    agents:
+      queue: default # should have AWS CLI installed and configured
+    command: |
+      echo "~~~ :hammer: Remove AWS credentials"
+      set -x
+      # Removing ~/.aws does not work and neither does clearing the AWS CLI env vars
+      aws configure set aws_access_key_id ""
+      aws configure set aws_secret_access_key ""
+      set +x
+      echo "--- :microscope: Run verify_aws_cli_setup"
+      if bin/verify_aws_cli_setup; then
+        echo "Error: Script succeeded but should have failed (AWS credentials not present)"
+        exit 1
+      else
+        echo "Success: Script failed as expected when AWS credentials not present"
+      fi
+    notify:
+      - github_commit_status:
+          context: "verify_aws_cli_setup Test fails when missing AWS credentials"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -118,3 +118,14 @@ steps:
         notify:
           - github_commit_status:
               context: "pr_changed_files Tests: Edge Cases"
+
+  - label: ":aws: verify_aws_cli_setup Test succeeds when AWS CLI setup"
+    agents:
+      queue: default
+    # We know the default queue has AWS CLI installed, so this should pass
+    command: |
+      echo "--- :microscope: Run verify_aws_cli_setup"
+      bin/verify_aws_cli_setup
+    notify:
+      - github_commit_status:
+          context: "verify_aws_cli_setup Test succeeds when AWS CLI setup"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,8 +123,8 @@ steps:
     steps:
       - label: ":aws: Test succeeds when AWS CLI setup"
         agents:
-          queue: default
-        # We know the default queue has AWS CLI installed, so this should pass
+          queue: mac
+        # We know the mac queue has AWS CLI installed, so this should pass
         command: |
           echo "--- :microscope: Run verify_aws_cli_setup"
           bin/verify_aws_cli_setup
@@ -154,7 +154,7 @@ steps:
 
       - label: ":aws: Test fails when missing AWS credentials"
         agents:
-          queue: default # should have AWS CLI installed and configured
+          queue: mac # should have AWS CLI installed and configured
         command: |
           echo "~~~ :hammer: Remove AWS credentials"
           set -x

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -24,7 +24,7 @@ steps:
     agents:
       queue: default
 
-  - label: ":radioactive_sign: Danger - PR Check"
+  - label: ":danger: Danger - PR Check"
     command: danger
     key: danger
     if: build.pull_request.id != null

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,54 +119,56 @@ steps:
           - github_commit_status:
               context: "pr_changed_files Tests: Edge Cases"
 
-  - label: ":aws: verify_aws_cli_setup Test succeeds when AWS CLI setup"
-    agents:
-      queue: default
-    # We know the default queue has AWS CLI installed, so this should pass
-    command: |
-      echo "--- :microscope: Run verify_aws_cli_setup"
-      bin/verify_aws_cli_setup
-    notify:
-      - github_commit_status:
-          context: "verify_aws_cli_setup Test succeeds when AWS CLI setup"
+  - group: ":aws: verify_aws_cli_setup Tests"
+    steps:
+      - label: ":aws: Test succeeds when AWS CLI setup"
+        agents:
+          queue: default
+        # We know the default queue has AWS CLI installed, so this should pass
+        command: |
+          echo "--- :microscope: Run verify_aws_cli_setup"
+          bin/verify_aws_cli_setup
+        notify:
+          - github_commit_status:
+              context: "verify_aws_cli_setup Test succeeds when AWS CLI setup"
 
-  - label: ":aws: verify_aws_cli_setup Test fails when missing AWS"
-    agents:
-      queue: default
-    plugins:
-      # Alpine shouldn't have AWS CLI installed, so this should fail
-      - docker#v5.7.0:
-          image: "alpine:latest"
-          propagate-exit-status: false
-    command: |
-      echo "--- :microscope: Run verify_aws_cli_setup"
-      if bin/verify_aws_cli_setup; then
-        echo "Error: Script succeeded but should have failed (AWS CLI not present in container)"
-        exit 1
-      else
-        echo "Success: Script failed as expected when AWS CLI not present"
-      fi
-    notify:
-      - github_commit_status:
-          context: "verify_aws_cli_setup Test fails when missing AWS"
+      - label: ":aws: Test fails when missing AWS"
+        agents:
+          queue: default
+        plugins:
+          # Alpine shouldn't have AWS CLI installed, so this should fail
+          - docker#v5.7.0:
+              image: "alpine:latest"
+              propagate-exit-status: false
+        command: |
+          echo "--- :microscope: Run verify_aws_cli_setup"
+          if bin/verify_aws_cli_setup; then
+            echo "Error: Script succeeded but should have failed (AWS CLI not present in container)"
+            exit 1
+          else
+            echo "Success: Script failed as expected when AWS CLI not present"
+          fi
+        notify:
+          - github_commit_status:
+              context: "verify_aws_cli_setup Test fails when missing AWS"
 
-  - label: ":aws: verify_aws_cli_setup Test fails when missing AWS credentials"
-    agents:
-      queue: default # should have AWS CLI installed and configured
-    command: |
-      echo "~~~ :hammer: Remove AWS credentials"
-      set -x
-      # Removing ~/.aws does not work and neither does clearing the AWS CLI env vars
-      aws configure set aws_access_key_id ""
-      aws configure set aws_secret_access_key ""
-      set +x
-      echo "--- :microscope: Run verify_aws_cli_setup"
-      if bin/verify_aws_cli_setup; then
-        echo "Error: Script succeeded but should have failed (AWS credentials not present)"
-        exit 1
-      else
-        echo "Success: Script failed as expected when AWS credentials not present"
-      fi
-    notify:
-      - github_commit_status:
-          context: "verify_aws_cli_setup Test fails when missing AWS credentials"
+      - label: ":aws: Test fails when missing AWS credentials"
+        agents:
+          queue: default # should have AWS CLI installed and configured
+        command: |
+          echo "~~~ :hammer: Remove AWS credentials"
+          set -x
+          # Removing ~/.aws does not work and neither does clearing the AWS CLI env vars
+          aws configure set aws_access_key_id ""
+          aws configure set aws_secret_access_key ""
+          set +x
+          echo "--- :microscope: Run verify_aws_cli_setup"
+          if bin/verify_aws_cli_setup; then
+            echo "Error: Script succeeded but should have failed (AWS credentials not present)"
+            exit 1
+          else
+            echo "Success: Script failed as expected when AWS credentials not present"
+          fi
+        notify:
+          - github_commit_status:
+              context: "verify_aws_cli_setup Test fails when missing AWS credentials"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ _None._
 ### New Features
 
 - Enhance `pr_changed_files` command to support both exit codes (default) and "true"/"false" string output (via `--stdout` flag) [#151]
+- Add `verify_aws_cli_setup` command to verify the AWS CLI can authenticate with AWS [#162]
+- `restore_cache` and `save_cache` use verify the AWS CLI can authenticate with AWS before running. If AWS cannot be reached, they `exit 0` to avoid failing the build that called them [#162]
 
 ### Bug Fixes
 

--- a/bin/cache_repo
+++ b/bin/cache_repo
@@ -1,5 +1,15 @@
 #!/bin/bash -eu
 
+if ! "$(dirname "${BASH_SOURCE[0]}")/verify_aws_cli_setup"; then
+	echo "^^^ +++"
+	echo "AWS CLI setup check failed! Will bypass creating the repo cache..."
+	# TODO: Add options parsing to configure whether to fail here or skip.
+	#
+	# Currently skipping because we know something stopped working in Linux
+	# queues with the AWS CLI and we don't want to break the build for clients.
+	exit 0
+fi
+
 AWS_BUCKET=$1
 
 DATE=$(date +"%Y-%m-%d")

--- a/bin/download_artifact
+++ b/bin/download_artifact
@@ -1,5 +1,11 @@
 #!/bin/bash -eu
 
+if ! "$(dirname "${BASH_SOURCE[0]}")/verify_aws_cli_setup"; then
+	echo "^^^ +++"
+	echo "AWS CLI setup check failed! Downloading the artifact would fail too."
+	exit 1
+fi
+
 # Usage
 # download_artifact $file_name [$destination]
 #

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -1,5 +1,15 @@
 #!/bin/bash -eu
 
+if ! "$(dirname "${BASH_SOURCE[0]}")/verify_aws_cli_setup"; then
+	echo "^^^ +++"
+	echo "AWS CLI setup check failed! Will bypass restoring the cache..."
+	# TODO: Add options parsing to configure whether to fail here or skip.
+	#
+	# Currently skipping because we know something stopped working in Linux
+	# queues with the AWS CLI and we don't want to break the build for clients.
+	exit 0
+fi
+
 CACHE_KEY=$1
 
 bytes_to_mb() {

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,5 +1,15 @@
 #!/bin/bash -eu
 
+if ! "$(dirname "${BASH_SOURCE[0]}")/verify_aws_cli_setup"; then
+	echo "^^^ +++"
+	echo "AWS CLI setup check failed! Will bypass saving the cache..."
+	# TODO: Add options parsing to configure whether to fail here or skip.
+	#
+	# Currently skipping because we know something stopped working in Linux
+	# queues with the AWS CLI and we don't want to break the build for clients.
+	exit 0
+fi
+
 CACHE_FILE=$1
 CACHE_KEY=$2
 

--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -1,5 +1,11 @@
 #!/bin/bash -eu
 
+if ! "$(dirname "${BASH_SOURCE[0]}")/verify_aws_cli_setup"; then
+	echo "^^^ +++"
+	echo "AWS CLI setup check failed! Uploading the artifact would fail too."
+	exit 1
+fi
+
 # Usage
 # upload_artifact $file_path
 #

--- a/bin/verify_aws_cli_setup
+++ b/bin/verify_aws_cli_setup
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+
+echo "~~~ Ensuring AWS CLI is installed and configured."
+
+# Check if aws command is available
+if ! command -v aws &> /dev/null; then
+  echo "[!] AWS CLI not found."
+  exit 1
+else
+  echo "AWS CLI found."
+fi
+
+# Check if AWS credentials are configured
+if ! aws sts get-caller-identity &> /dev/null; then
+  echo "[!] AWS credentials not found."
+  exit 1
+else
+  echo "AWS credentials found."
+fi

--- a/bin/verify_aws_cli_setup
+++ b/bin/verify_aws_cli_setup
@@ -1,19 +1,52 @@
 #!/bin/bash -eu
 
-echo "~~~ Ensuring AWS CLI is installed and configured."
+echo "--- :aws: Ensuring AWS CLI is installed and configured..."
 
-# Check if aws command is available
+echo "~~~ Checking if AWS CLI is installed..."
 if ! command -v aws &> /dev/null; then
   echo "[!] AWS CLI not found."
   exit 1
 else
-  echo "AWS CLI found."
+  echo "AWS CLI found at $(which aws)."
+  aws --version
 fi
 
-# Check if AWS credentials are configured
+echo "~~~ Checking if AWS credentials are configured in env vars or config files..."
+
+if [ -n "${AWS_ACCESS_KEY_ID:-}" ]; then
+    echo "AWS_ACCESS_KEY_ID found in environment variables."
+else
+    echo "No AWS_ACCESS_KEY_ID in environment variables."
+fi
+
+if [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    echo "AWS_SECRET_ACCESS_KEY found in environment variables."
+else
+    echo "No AWS_SECRET_ACCESS_KEY in environment variables."
+fi
+
+AWS_CONFIG_PATH="$HOME/.aws/config"
+if [ -f "$AWS_CONFIG_PATH" ]; then
+    echo "AWS config file exists at $AWS_CONFIG_PATH."
+    echo "Printing config via aws configure list:"
+    aws configure list
+else
+    echo "No AWS config file found at $AWS_CONFIG_PATH."
+fi
+
+AWS_CREDENTIALS_PATH="$HOME/.aws/credentials"
+if [ -f "$AWS_CREDENTIALS_PATH" ]; then
+    echo "AWS credentials file exists at $AWS_CREDENTIALS_PATH."
+    echo "Printing profiles via aws configure list:"
+    aws configure list-profiles
+else
+    echo "No AWS credentials file found at $AWS_CREDENTIALS_PATH."
+fi
+
+echo "~~~ Checking AWS credentials via CLI call..."
 if ! aws sts get-caller-identity &> /dev/null; then
-  echo "[!] AWS credentials not found."
+  echo "[!] AWS credentials check failed."
   exit 1
 else
-  echo "AWS credentials found."
+  echo "AWS credentials verified successfully."
 fi


### PR DESCRIPTION
Earlier today, @geekygecko reported (ref p1740374258002719/1740354379.359239-slack-CC7L49W13) an [odd failure in Buildkite](https://buildkite.com/automattic/pocket-casts-android/builds/10679#019535dd-890f-413d-9c9c-2e0494ee8fe5):

```
[2025-02-24T02:52:22Z] Using a8c-ci-cache as cache bucket
[2025-02-24T02:52:23Z] Restoring cache entry pocket-casts-android-Linux-x86_64-ruby3.2.2-7540d16bf427a0fd78072941f12b6d55fedfdd343dd59353ad9ed1f26c4dc8f9
[2025-02-24T02:52:23Z] 	Downloading
[2025-02-24T02:52:25Z]
[2025-02-24T02:52:25Z] Unable to locate credentials. You can configure credentials by running "aws configure".
🔐 Installing Secrets
[2025-02-24T02:52:26Z] bundler: command not found: fastlane
[2025-02-24T02:52:26Z] Install missing gem executables with `bundle install`
```

Looking through the `restore_cache` implementation, I'd say this was due to the bucket acceleration check failing in a `|| true` combo.

https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/df99bdfb1590bdb55ae69af2d3098f24afdcb9ec/bin/restore_cache#L29

While the `|| true` makes sense, it comes at the price of swallowing an occasional error such as this one.

I don't know how the error occurred and it looks like just a hiccup because upon retry the same step [worked fine](https://buildkite.com/automattic/pocket-casts-android/builds/10679#019536da-8011-4e10-921a-7748ebfd0664).

Still, I think it doesn't hurt to be proactive and to fail early if we have issue with the AWS CLI setup. If anything, It would make it clearer for the user why the build failed.

This PR introduces as command to check that the AWS CLI is available and the credentials are set up. 

---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.