### PR TITLE
Prepare release `4.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Enhance `pr_changed_files` command to support both exit codes (default) and "true"/"false" string output (via `--stdout` flag) [#151]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 4.0.0
+
+### Breaking Changes
+
+- `pr_changed_files` command now uses exit codes by default, with stdout output requiring explicit `--stdout` flag [#151]
 
 ## 3.11.0
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#3.11.0:
+      - automattic/a8c-ci-toolkit#4.0.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `3.11.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `4.0.0`.
 
 ## Configuration
 


### PR DESCRIPTION
This PR prepares the release of version 4.0.0.

Breaking Changes:
- `pr_changed_files` command now uses exit codes by default, with stdout output requiring explicit `--stdout` flag [#151]
