### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ _None._
 
 ### Breaking Changes
 
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 5.0.0
+
+### Breaking Changes
+
 - `prepare_windows_host_for_node.ps1` has been renamed to `prepare_windows_host_for_app_distribution.ps1` [#144]
 - `prepare_windows_host_for_app_distribution.ps1` no longer installs Node.js.
   Clients should use [`nvm-buildkite-plugin`](https://github.com/Automattic/nvm-buildkite-plugin) instead [#144]
@@ -43,14 +61,6 @@ _None._
 - Added new command to install Windows 10 SDK on Windows CI machines, `install_windows_10_sdk.ps1` [#144]
 - `prepare_windows_host_for_app_distribution.ps1` automatically installs the Windows 10 SDK if version file is found [#144]
 - Added new command to run `refreshenv` on Windows preserving the `PATH`, `path_aware_refreshenv.ps1` [#144]
-
-### Bug Fixes
-
-_None._
-
-### Internal Changes
-
-_None._
 
 ## 4.0.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 # Migration Instructions for Major Releases
 
+## From 3.0.0 to 4.0.0
+
+* In 4.0.0, the `pr_changed_files` command uses exit codes by default.
+  To flag to replicate the previous behavior with stdout output, use the `--stdout`.
+
 ## From 2.0.0 to 3.0.0
 
 * The `nvm_install` utility has been removed in 3.0.0. Here are the detailed migration steps:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,10 @@
 # Migration Instructions for Major Releases
 
+## From 4.0.0 to 5.0.0
+
+* Use `prepare_windows_host_for_app_distribution.ps1` instead of `prepare_windows_host_for_node.ps1`.
+* This plugin no longer sets up Node.js in Windows clients, us use [`nvm-buildkite-plugin`](https://github.com/Automattic/nvm-buildkite-plugin) instead.
+
 ## From 3.0.0 to 4.0.0
 
 * In 4.0.0, the `pr_changed_files` command uses exit codes by default.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#4.0.0:
+      - automattic/a8c-ci-toolkit#5.0.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `4.0.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `5.0.0`.
 
 ## Configuration
 


### PR DESCRIPTION
Process breadcrumb PR for 5.0.0 release. 

If CI is green, I'll proceed with the release steps as documented in the README.

---

I noticed that 4.0.0, #163, went through code review. However, I released other versions in the past with this same workflow (namely, admin-merging them) with no complaint, e.g. https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/137

The README makes no mention of code reviewing the release PRs, but neither says it's okay to admin-merge them.

I think in this case admin-merging is okay. In particular for this repo that we 100% own and where we have already agreed that releases are cheap. 

I guess #163 went through code review because of timezone overlap and collaboration, rather than for an explicit need for code reviews.

I've documented all this so we can discuss and maybe update the readme accordingly, either with "it's okay to admin merge" or with a new step to "request a code review".