### PR TITLE
Make tldr part `diff` and colorize headers

### DIFF
--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -126,12 +126,16 @@ modify_tldr_diff_file() {
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$TLDR_DIFF_DEPENDENCIES_FILE
 
-modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
+if [[ -f "$TLDR_DIFF_DEPENDENCIES_FILE" ]]; then
+  modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
+fi
 
 ./dependency-tree-diff.jar $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$TLDR_DIFF_BUILD_ENV_FILE
 
-modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
+if [[ -f "$TLDR_DIFF_BUILD_ENV_FILE" ]]; then
+  modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
+fi
 
 echo "--> Preparing comment for GitHub"
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -112,6 +112,13 @@ JAR_DIR="$REPO_ROOT/jar"
 
 echo "--> Running dependency-tree-diff.jar"
 
+modify_tldr_diff_file() {
+    local file="$1"
+    sed -i '' -e 's/^New Dependencies$/+ New Dependencies/' \
+              -e 's/^Upgraded Dependencies$/! Upgraded Dependencies/' \
+              -e 's/^Removed Dependencies$/- Removed Dependencies/' "$file"
+}
+
 # This script uses the 'dependency-diff-tldr' tool to summarize dependency differences.
 # Source code: https://github.com/careem/dependency-diff-tldr
 # Version: v0.0.6 (commit: 953a153)
@@ -119,8 +126,12 @@ echo "--> Running dependency-tree-diff.jar"
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$TLDR_DIFF_DEPENDENCIES_FILE
 
+modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
+
 ./dependency-tree-diff.jar $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$TLDR_DIFF_BUILD_ENV_FILE
+
+modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
 
 echo "--> Preparing comment for GitHub"
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -114,9 +114,13 @@ echo "--> Running dependency-tree-diff.jar"
 
 modify_tldr_diff_file() {
     local file="$1"
-    sed -i '' -e 's/^New Dependencies$/+ New Dependencies/' \
-              -e 's/^Upgraded Dependencies$/! Upgraded Dependencies/' \
-              -e 's/^Removed Dependencies$/- Removed Dependencies/' "$file"
+    if [[ -f "$file" && -s "$file" ]]; then
+      sed -i -e 's/^New Dependencies$/+ New Dependencies/' \
+             -e 's/^Upgraded Dependencies$/! Upgraded Dependencies/' \
+             -e 's/^Removed Dependencies$/- Removed Dependencies/' "$file"
+    else
+        echo "Decorating tldr didn't work: file $file does not exist or is empty."
+    fi
 }
 
 # This script uses the 'dependency-diff-tldr' tool to summarize dependency differences.
@@ -126,16 +130,12 @@ modify_tldr_diff_file() {
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$TLDR_DIFF_DEPENDENCIES_FILE
 
-if [[ -s "$TLDR_DIFF_DEPENDENCIES_FILE" ]]; then
-  modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
-fi
+modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
 
 ./dependency-tree-diff.jar $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$TLDR_DIFF_BUILD_ENV_FILE
 
-if [[ -s "$TLDR_DIFF_BUILD_ENV_FILE" ]]; then
-  modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
-fi
+modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
 
 echo "--> Preparing comment for GitHub"
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -126,14 +126,14 @@ modify_tldr_diff_file() {
 ./dependency-tree-diff.jar $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$DIFF_DEPENDENCIES_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_DEPENDENCIES_FILE $HEAD_BRANCH_DEPENDENCIES_FILE >$TLDR_DIFF_DEPENDENCIES_FILE
 
-if [[ -f "$TLDR_DIFF_DEPENDENCIES_FILE" ]]; then
+if [[ -s "$TLDR_DIFF_DEPENDENCIES_FILE" ]]; then
   modify_tldr_diff_file "$TLDR_DIFF_DEPENDENCIES_FILE"
 fi
 
 ./dependency-tree-diff.jar $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$DIFF_BUILD_ENV_FILE
 java -jar "$JAR_DIR/dependency-diff-tldr-0.0.6.jar" $BASE_BRANCH_BUILD_ENV_FILE $HEAD_BRANCH_BUILD_ENV_FILE >$TLDR_DIFF_BUILD_ENV_FILE
 
-if [[ -f "$TLDR_DIFF_BUILD_ENV_FILE" ]]; then
+if [[ -s "$TLDR_DIFF_BUILD_ENV_FILE" ]]; then
   modify_tldr_diff_file "$TLDR_DIFF_BUILD_ENV_FILE"
 fi
 

--- a/bin/craft_comment_with_dependency_diff
+++ b/bin/craft_comment_with_dependency_diff
@@ -32,7 +32,8 @@ print_tree() {
 %s
 \`\`\`
 
-</details>" "$1"
+</details>
+" "$1"
 }
 
 print_tree_too_large() {

--- a/bin/craft_comment_with_dependency_diff
+++ b/bin/craft_comment_with_dependency_diff
@@ -11,7 +11,7 @@ current_size=0
 
 # Templates for content formatting
 print_header() {
-    printf "## %s changes\n\n" "$1"
+    printf "\n## %s changes\n\n" "$1"
 }
 
 print_tldr() {

--- a/bin/craft_comment_with_dependency_diff
+++ b/bin/craft_comment_with_dependency_diff
@@ -17,7 +17,7 @@ print_header() {
 print_tldr() {
     printf "<details><summary>list</summary>
 
-\`\`\`
+\`\`\`diff
 %s
 \`\`\`
 
@@ -45,7 +45,7 @@ tldr_size=0
 for section in "Project dependencies" "Build environment"; do
     tldr_file="$TLDR_DIFF_DEPENDENCIES_FILE"
     [[ $section == "Build environment" ]] && tldr_file="$TLDR_DIFF_BUILD_ENV_FILE"
-    
+
     if [ -s "$tldr_file" ]; then
         content=$(print_header "$section"; print_tldr "$(cat "$tldr_file")")
         tldr_size=$(( tldr_size + ${#content} ))
@@ -66,13 +66,13 @@ for section in "Project dependencies" "Build environment"; do
     tldr_file="$TLDR_DIFF_DEPENDENCIES_FILE"
     tree_file="$DIFF_DEPENDENCIES_FILE"
     [[ $section == "Build environment" ]] && tldr_file="$TLDR_DIFF_BUILD_ENV_FILE" && tree_file="$DIFF_BUILD_ENV_FILE"
-    
+
     if [ -s "$tldr_file" ]; then
         # Print section header and TLDR
         print_header "$section" >> "$COMMENT_FILE"
         print_tldr "$(cat "$tldr_file")" >> "$COMMENT_FILE"
         current_size=$(wc -c < "$COMMENT_FILE")
-        
+
         # Try to add tree if it exists
         if [ -s "$tree_file" ]; then
             tree_content=$(cat "$tree_file")


### PR DESCRIPTION
To simply make it nicer

| Before | After | 
| --- | --- |
| <img width="827" alt="Screenshot 2025-03-05 at 16 36 42" src="https://github.com/user-attachments/assets/4f33863a-ebfb-4cf9-9f97-2a89be9b306e" /> | <img width="814" alt="image" src="https://github.com/user-attachments/assets/c243ba1b-9cd7-4d5f-9248-d54172c7fcdc" /> |


---

- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
