### PR TITLE
[AndroidManifest] Improve Merged Manifest Diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Update `comment_with_manifest_diff` command to respect base branch changes prior head branch manifest generation [#173]
 
 ### Internal Changes
 

--- a/bin/comment_with_manifest_diff
+++ b/bin/comment_with_manifest_diff
@@ -75,6 +75,7 @@ fi
 # Generate head branch manifest
 echo "--> Switching back to head branch"
 git checkout "-"
+git merge "origin/$BASE_BRANCH" --no-edit
 echo "--> Generating head branch manifest"
 ./gradlew "${GRADLE_TASK}"
 echo ""


### PR DESCRIPTION
Project Thread: paaHJt-7Tl-p2
Related: #164 
Tested By: [PCAndroid#3747](https://github.com/Automattic/pocket-casts-android/pull/3747)

---

## Description

This PR merges the `base` branch changes into `head` branch prior initiating the merged manifest generation for the `head` branch.

As reported already (p1741594194983279/1740493471.859349-slack-C030U03RC8Y), on some PRs ([example](https://github.com/Automattic/pocket-casts-android/pull/3743)), version code/name changes are detected because the head branch wasn't synced with the base branch. In order to avoid such false positives, this change merges the base branch into the head prior to generating the head manifest. This way, comparing the base and head manifest changes will always produce the most appropriate result.

---

## Test Instructions

You could check [PCAndroid#3747](https://github.com/Automattic/pocket-casts-android/pull/3747) test PR and follow the testing instruction there.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.