### PR TITLE
[Diff] Enhance Comment with Dependency/Manifest Diff with Git Fetch/Pull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Update `comment_with_manifest_diff` and `comment_with_dependency_diff` commands with extra `git fetch/pull` calls to make both of them work as expected on all CI environments. [#177]
 
 ## 5.2.0
 

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -61,6 +61,8 @@ export TLDR_DIFF_BUILD_ENV_FILE="$DIFF_DEPENDENCIES_FOLDER/tldr_diff_build_env.t
 git config --global user.email "mobile@automattic.com"
 git config --global user.name "Dependency Tree Diff Tool"
 
+git fetch
+
 echo "--> Starting the check"
 BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
 echo "--> Base branch is $BASE_BRANCH"

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -93,6 +93,7 @@ if ! git diff --quiet; then
 fi
 
 git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
 ./gradlew :"$MODULE":dependencies --configuration "$CONFIGURATION" >$BASE_BRANCH_DEPENDENCIES_FILE
 
 echo "--> Generating build environment dependencies for the base branch"

--- a/bin/comment_with_manifest_diff
+++ b/bin/comment_with_manifest_diff
@@ -63,6 +63,7 @@ echo "--> Base branch is $BASE_BRANCH"
 # Generate base branch manifest
 echo "--> Switching to base branch"
 git checkout "$BASE_BRANCH"
+git pull origin "$BASE_BRANCH"
 echo "--> Generating base branch manifest"
 ./gradlew "${GRADLE_TASK}"
 echo ""

--- a/bin/comment_with_manifest_diff
+++ b/bin/comment_with_manifest_diff
@@ -54,6 +54,8 @@ mkdir -p "$DIFF_MANIFEST_FOLDER"
 git config --global user.email "mobile@automattic.com"
 git config --global user.name "Android Manifest Diff Tool"
 
+git fetch
+
 echo "--> Starting Android Manifest diff check"
 BASE_BRANCH=$BUILDKITE_PULL_REQUEST_BASE_BRANCH
 echo "--> Base branch is $BASE_BRANCH"


### PR DESCRIPTION
Project Thread: paaHJt-7Tl-p2
Tested By:
- Manifest Diff:
    - GHE: [TBAndroid#24349](https://github.tumblr.net/Tumblr/android/pull/24349) + [TBAndroid#24350](https://github.tumblr.net/Tumblr/android/pull/24350)
    - GH: [WCAndroid#13791](https://github.com/woocommerce/woocommerce-android/pull/13791) + [WCAndroid#13792](https://github.com/woocommerce/woocommerce-android/pull/13792)
- Dependency Diff:
    - GHE: [TBAndroid#24353](https://github.tumblr.net/Tumblr/android/pull/24353)
    - GH: [WCAndroid#13791](https://github.com/woocommerce/woocommerce-android/pull/13791) + [WCAndroid#13792](https://github.com/woocommerce/woocommerce-android/pull/13792)

---

## Description

This PR is about enhancing [comment_with_manifest_diff](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/trunk/bin/comment_with_manifest_diff) (but also [comment_with_dependency_diff](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/trunk/bin/comment_with_dependency_diff)) so that it works as expected with project like [TBAndroid](https://github.tumblr.net/Tumblr/android) where the base branch is **NOT** always up-to-date and at all times, just like it happens on all other projects (see p1742298963526779/1742288408.868439-slack-C0211NP7Y5U).

---

## Test Instructions

- Manifest Diff:

You could check this [TBAndroid#24349](https://github.tumblr.net/Tumblr/android/pull/24349) PR, along with it's test PR [TBAndroid#24350](https://github.tumblr.net/Tumblr/android/pull/24350) and see when and how such [comments](https://github.tumblr.net/Tumblr/android/pull/24350#issuecomment-696383) might appear:

![image](https://github.com/user-attachments/assets/2266c463-cc55-49fe-aa40-5941a0aa2c1a)

- Dependency Diff:

You could check [TBAndroid#24353](https://github.tumblr.net/Tumblr/android/pull/24353) test PR and see when and how such [comment](https://github.tumblr.net/Tumblr/android/pull/24353#issuecomment-696389) might appear: 

![image](https://github.com/user-attachments/assets/ca768c5f-9d74-498d-bbc8-6de402fb4ab5)

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.