### PR TITLE
Specify category on sarif upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Allow to specify category on `sarif` files upload [#183]
 
 ### Bug Fixes
 

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 sarif_file="${1:-}"
+category="${2:-}"
 
 [[ $BUILDKITE_REPO =~ ^(https?://|git@)([^/:]+)[/:](.*)$ ]] && slug=${BASH_REMATCH[3]%%.git}
 if [[ -z "${slug:-}" ]]; then
@@ -11,7 +12,7 @@ if [[ -z "${slug:-}" ]]; then
 fi
 
 if [ -z "$sarif_file" ]; then
-  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report>"
+  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report> [category]"
   exit 1
 fi
 
@@ -29,6 +30,19 @@ fi
 if [ -z "${GITHUB_TOKEN:-}" ]; then
   echo "Error: GITHUB_TOKEN is not defined."
   exit 1
+fi
+
+# Modify SARIF file if category is provided
+if [ -n "$category" ]; then
+  sarif_temp_file=$(mktemp)
+  jq --arg category "$category" '
+    .runs |= map(
+      .automationDetails = {
+        "id": ($category + "/")
+      }
+    )
+  ' "$sarif_file" > "$sarif_temp_file"
+  sarif_file="$sarif_temp_file"
 fi
 
 sarif_base64_temp_file=$(mktemp)

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 sarif_file="${1:-}"
+tool_name="${2:-}"
 
 [[ $BUILDKITE_REPO =~ ^(https?://|git@)([^/:]+)[/:](.*)$ ]] && slug=${BASH_REMATCH[3]%%.git}
 if [[ -z "${slug:-}" ]]; then
@@ -11,7 +12,7 @@ if [[ -z "${slug:-}" ]]; then
 fi
 
 if [ -z "$sarif_file" ]; then
-  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report>"
+  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report> [tool-name]"
   exit 1
 fi
 
@@ -31,35 +32,34 @@ if [ -z "${GITHUB_TOKEN:-}" ]; then
   exit 1
 fi
 
-sarif_base64_temp_file=$(mktemp)
+tmp_sarif=$(mktemp)
+gzip -c "$sarif_file" | base64 > "$tmp_sarif"
 
-gzip -c "$sarif_file" | base64 > "$sarif_base64_temp_file"
-
+ref=""
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
-  json=$(jq -n \
-    --arg commit_sha "$BUILDKITE_COMMIT" \
-    --arg pr_number "$BUILDKITE_PULL_REQUEST" \
-    --rawfile sarif "$sarif_base64_temp_file" \
-    '{
-     "commit_sha": $commit_sha,
-     "ref": ("refs/pull/"+$pr_number+"/head"),
-     "sarif": $sarif
-   }')
+  ref="refs/pull/$BUILDKITE_PULL_REQUEST/head"
 elif [[ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
-  json=$(jq -n \
-    --arg commit_sha "$BUILDKITE_COMMIT" \
-    --arg branch "$BUILDKITE_BRANCH" \
-    --rawfile sarif "$sarif_base64_temp_file" \
-    '{
-     "commit_sha": $commit_sha,
-     "ref": ("refs/heads/"+$branch),
-     "sarif": $sarif
-   }')
+  ref="refs/heads/$BUILDKITE_BRANCH"
 else
   exit 0
 fi
 
-sarif_json_temp_file=$(mktemp)
-echo "$json" > "$sarif_json_temp_file"
+jq_args=(
+  --arg commit_sha "$BUILDKITE_COMMIT"
+  --arg ref "$ref"
+  --rawfile sarif "$tmp_sarif"
+)
 
-github_api "repos/$slug/code-scanning/sarifs" --data-binary "@$sarif_json_temp_file"
+if [[ -n "$tool_name" ]]; then
+  jq_args+=(--arg tool_name "$tool_name")
+fi
+
+jq -n "${jq_args[@]}" '
+  {
+    commit_sha: $commit_sha,
+    ref: $ref,
+    sarif: $sarif
+  } + ( $tool_name? // {} )
+' > sarif_payload.json
+
+github_api "repos/$slug/code-scanning/sarifs" --data-binary @sarif_payload.json

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 sarif_file="${1:-}"
-tool_name="${2:-}"
 
 [[ $BUILDKITE_REPO =~ ^(https?://|git@)([^/:]+)[/:](.*)$ ]] && slug=${BASH_REMATCH[3]%%.git}
 if [[ -z "${slug:-}" ]]; then
@@ -12,7 +11,7 @@ if [[ -z "${slug:-}" ]]; then
 fi
 
 if [ -z "$sarif_file" ]; then
-  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report> [tool-name]"
+  echo "Not enough arguments provided. Usage: ./upload_sarif_to_gh.sh <path to .sarif report>"
   exit 1
 fi
 
@@ -32,35 +31,35 @@ if [ -z "${GITHUB_TOKEN:-}" ]; then
   exit 1
 fi
 
-tmp_sarif=$(mktemp)
-gzip -c "$sarif_file" | base64 > "$tmp_sarif"
+sarif_base64_temp_file=$(mktemp)
 
-ref=""
+gzip -c "$sarif_file" | base64 > "$sarif_base64_temp_file"
+
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" != "false" ]]; then
-  ref="refs/pull/$BUILDKITE_PULL_REQUEST/head"
+  json=$(jq -n \
+    --arg commit_sha "$BUILDKITE_COMMIT" \
+    --arg pr_number "$BUILDKITE_PULL_REQUEST" \
+    --rawfile sarif "$sarif_base64_temp_file" \
+    '{
+     "commit_sha": $commit_sha,
+     "ref": ("refs/pull/"+$pr_number+"/head"),
+     "sarif": $sarif
+   }')
 elif [[ "$BUILDKITE_BRANCH" == "$BUILDKITE_PIPELINE_DEFAULT_BRANCH" ]]; then
-  ref="refs/heads/$BUILDKITE_BRANCH"
+  json=$(jq -n \
+    --arg commit_sha "$BUILDKITE_COMMIT" \
+    --arg branch "$BUILDKITE_BRANCH" \
+    --rawfile sarif "$sarif_base64_temp_file" \
+    '{
+     "commit_sha": $commit_sha,
+     "ref": ("refs/heads/"+$branch),
+     "sarif": $sarif
+   }')
 else
   exit 0
 fi
 
-jq_args=(
-  --arg commit_sha "$BUILDKITE_COMMIT"
-  --arg ref "$ref"
-  --rawfile sarif "$tmp_sarif"
-)
+sarif_json_temp_file=$(mktemp)
+echo "$json" > "$sarif_json_temp_file"
 
-if [[ -n "$tool_name" ]]; then
-  jq_args+=(--arg tool_name "$tool_name")
-fi
-
-jq -n "${jq_args[@]}" '
-  {
-    commit_sha: $commit_sha,
-    ref: $ref,
-    sarif: $sarif
-  }
-  + ( $tool_name? | if . != null then { tool_name: . } else empty end )
-' > sarif_payload.json
-
-github_api "repos/$slug/code-scanning/sarifs" --data-binary @sarif_payload.json
+github_api "repos/$slug/code-scanning/sarifs" --data-binary "@$sarif_json_temp_file"

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -59,7 +59,8 @@ jq -n "${jq_args[@]}" '
     commit_sha: $commit_sha,
     ref: $ref,
     sarif: $sarif
-  } + ( $tool_name? // {} )
+  }
+  + ( $tool_name? | if . != null then { tool_name: . } else empty end )
 ' > sarif_payload.json
 
 github_api "repos/$slug/code-scanning/sarifs" --data-binary @sarif_payload.json


### PR DESCRIPTION
Closes: AINFRA-979

### Description

[GH Docs: Uploading more than one SARIF file for a commit](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#uploading-more-than-one-sarif-file-for-a-commit)

When sending a `.sarif` file for a specific ref, they need to have a separate **category**. Otherwise, the results are overwritten, and this happens now in projects like Pocket Casts or WooCommerce Android: 

<img width="733" height="124" alt="image" src="https://github.com/user-attachments/assets/2bdacfab-62eb-4005-85e8-78eb7fb4ef8c" />

As we don't use GitHub Actions, to specify **category** we have to provide `runAutomationDetails` object ([reference](https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html#_Toc16012479)). This PR does exactly this.


### Testing

Here's a test PR: https://github.com/woocommerce/woocommerce-android/pull/14360

Compare [trunk results](https://github.com/woocommerce/woocommerce-android/security/code-scanning) and these from [the attached PR](https://github.com/woocommerce/woocommerce-android/security/code-scanning?query=is%3Aopen+pr%3A14360).

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
