### PR TITLE
Install Python during windows setup and add new Visual Studio Build tools components 

### DIFF
--- a/.buildkite/pipeline-windows-tests.yml
+++ b/.buildkite/pipeline-windows-tests.yml
@@ -99,6 +99,17 @@ steps:
           - github_commit_status:
               context: "install_windows_10_sdk Tests - Version file with version number that is not in the allowed list"
 
+  - group: ":snake: install_python Tests"
+    steps:
+      - label: ":snake: install_python Tests - Basic dry run with Chocolatey available"
+        command: |
+          .\tests\test_install_python.ps1 -ExpectedExitCode 0
+        agents:
+          queue: windows
+        notify:
+          - github_commit_status:
+              context: "install_python Tests - Basic dry run with Chocolatey available"
+
   - label: ":windows: prepare_windows_host_for_app_distribution Tests - Skip Windows 10 SDK Installation"
     command: .\tests\test_prepare_windows_host_for_app_distribution.ps1
     agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Install Python during windows setup and install additional Visual Studio Build Tools components for native builds [#186]
 
 ### Bug Fixes
 
@@ -53,7 +53,6 @@ _None._
 ### New Features
 
 - Allow to specify category on `sarif` files upload [#183]
-
 
 ## 5.3.1
 

--- a/bin/install_python.ps1
+++ b/bin/install_python.ps1
@@ -1,0 +1,72 @@
+<#
+.SYNOPSIS
+    Installs Python 3 via Chocolatey.
+
+.DESCRIPTION
+    This script installs Python 3 using the Chocolatey package manager. Python is required
+    for Node.js native module compilation as some Node.js packages require Python during
+    npm install for building native extensions.
+
+.EXAMPLE
+    .\install_python.ps1
+    Installs Python 3 via Chocolatey.
+
+.NOTES
+    Author: Automattic
+    Requirements: Windows PowerShell 5.1
+    Windows Requirements:
+        - Windows Server 2019 or later
+        - Chocolatey package manager must be installed
+        - Administrator privileges: Yes
+
+.OUTPUTS
+    Status messages indicating installation progress and results.
+
+.RETURNVALUES
+    0 - Success
+    1 - Installation failed
+    Non-zero - Chocolatey installation exit code
+#>
+
+# Stop script execution when a non-terminating error occurs
+$ErrorActionPreference = "Stop"
+
+Write-Output "--- :snake: Installing Python"
+
+# Check if Chocolatey is available
+try {
+    $chocoPath = Get-Command choco -ErrorAction Stop
+    Write-Output "Found Chocolatey at: $($chocoPath.Source)"
+} catch {
+    Write-Output "[!] Chocolatey is not installed or not available in PATH"
+    Write-Output "    Please ensure Chocolatey is installed before running this script"
+    exit 1
+}
+
+# Install Python 3 via Chocolatey for Node.js native module compilation
+# Some Node.js packages require Python during npm install for building native extensions
+Write-Output "Installing Python 3 via Chocolatey..."
+choco install python3 --yes --no-progress
+If ($LastExitCode -ne 0) { 
+    Write-Output "[!] Failed to install Python via Chocolatey"
+    Exit $LastExitCode 
+}
+
+# Refresh environment to make Python available in PATH
+Write-Output "Refreshing environment variables..."
+& "$PSScriptRoot\path_aware_refreshenv.ps1"
+If ($LastExitCode -ne 0) { 
+    Write-Output "[!] Failed to refresh environment after Python installation"
+    Exit $LastExitCode 
+}
+
+# Verify Python installation
+Write-Output "Verifying Python installation..."
+$pythonVersion = python --version 2>&1
+If ($LastExitCode -eq 0) {
+    Write-Output "Python installed successfully: $pythonVersion :tada:"
+} else {
+    Write-Output "[!] Python installation verification failed"
+    Write-Output "    Python command not found in PATH after installation"
+    Exit 1
+}

--- a/bin/install_python.ps1
+++ b/bin/install_python.ps1
@@ -52,7 +52,7 @@ try {
 } catch {
     Write-Output "[!] Chocolatey is not installed or not available in PATH"
     Write-Output "    Please ensure Chocolatey is installed before running this script"
-    exit 1
+    Exit 1
 }
 
 Write-Output "Will attempt to install Python 3 via Chocolatey..."

--- a/bin/install_python.ps1
+++ b/bin/install_python.ps1
@@ -7,9 +7,17 @@
     for Node.js native module compilation as some Node.js packages require Python during
     npm install for building native extensions.
 
+.PARAMETER DryRun
+    When specified, the script will validate dependencies and show what would be installed
+    without actually performing the installation.
+
 .EXAMPLE
     .\install_python.ps1
     Installs Python 3 via Chocolatey.
+
+.EXAMPLE
+    .\install_python.ps1 -DryRun
+    Validates dependencies and shows what would be installed without performing installation.
 
 .NOTES
     Author: Automattic
@@ -28,6 +36,10 @@
     Non-zero - Chocolatey installation exit code
 #>
 
+param (
+  [switch]$DryRun = $false
+)
+
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
@@ -41,6 +53,13 @@ try {
     Write-Output "[!] Chocolatey is not installed or not available in PATH"
     Write-Output "    Please ensure Chocolatey is installed before running this script"
     exit 1
+}
+
+Write-Output "Will attempt to install Python 3 via Chocolatey..."
+
+if ($DryRun) {
+  Write-Output "Running in dry run mode, finishing here."
+  exit 0
 }
 
 # Install Python 3 via Chocolatey for Node.js native module compilation

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -4,8 +4,8 @@
 # The list of valid component ids can be found at
 # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
 #
-# This script installs components required for Node.js native module compilation on Windows:
-# - Windows 10 SDK (configurable version)
+# This script installs the Windows 10 SDK by default.
+# Optionally, it can also install native compilation tools for building native modules:
 # - MSVC v143 compiler toolset (x64/x86)
 # - CMake tools for Visual Studio
 #
@@ -14,7 +14,8 @@
 #   20348
 
 param (
-  [switch]$DryRun = $false
+  [switch]$DryRun = $false,
+  [switch]$InstallNativeCompilationTools = $false
 )
 
 # Stop script execution when a non-terminating error occurs
@@ -60,6 +61,12 @@ if ($allowedVersions -notcontains $windows10SDKVersion) {
 
 Write-Output "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
 
+if ($InstallNativeCompilationTools) {
+  Write-Output "Native compilation tools requested. Will also install MSVC compiler toolset and CMake tools."
+} else {
+  Write-Output "Installing Windows 10 SDK only. Use -InstallNativeCompilationTools to include MSVC compiler and CMake tools."
+}
+
 if ($DryRun) {
   Write-Output "Running in dry run mode, finishing here."
   exit 0
@@ -81,15 +88,25 @@ If (-not (Test-Path $buildToolsPath)) {
   Write-Output "Successfully downloaded Visual Studio Build Tools at $buildToolsPath."
 }
 
-# Install the Windows SDK and other required components for Node.js native module compilation
-Write-Output "~~~ Installing Visual Studio Build Tools with Node.js native module support..."
+# Install the Windows SDK and (optionally) native compilation tools
+if ($InstallNativeCompilationTools) {
+  Write-Output "~~~ Installing Visual Studio Build Tools with native compilation tools..."
+} else {
+  Write-Output "~~~ Installing Visual Studio Build Tools with Windows 10 SDK..."
+}
 
-# Define components needed for Node.js native module compilation
+# Define base components (always installed)
 $components = @(
-  "Microsoft.VisualStudio.Component.Windows10SDK.$windows10SDKVersion",
-  "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",  # MSVC v143 compiler toolset
-  "Microsoft.VisualStudio.Component.VC.CMake.Project"   # CMake tools for native modules
+  "Microsoft.VisualStudio.Component.Windows10SDK.$windows10SDKVersion"
 )
+
+# Add native compilation tools if requested
+if ($InstallNativeCompilationTools) {
+  $components += @(
+    "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",  # MSVC v143 compiler toolset
+    "Microsoft.VisualStudio.Component.VC.CMake.Project"   # CMake tools for native modules
+  )
+}
 
 $argumentList = "--quiet --wait"
 foreach ($component in $components) {

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -4,6 +4,11 @@
 # The list of valid component ids can be found at
 # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
 #
+# This script installs components required for Node.js native module compilation on Windows:
+# - Windows 10 SDK (configurable version)
+# - MSVC v143 compiler toolset (x64/x86)
+# - CMake tools for Visual Studio
+#
 # Example:
 #
 #   20348
@@ -76,11 +81,26 @@ If (-not (Test-Path $buildToolsPath)) {
   Write-Output "Successfully downloaded Visual Studio Build Tools at $buildToolsPath."
 }
 
-# Install the Windows SDK and other required components
-Write-Output "~~~ Installing Visual Studio Build Tools..."
+# Install the Windows SDK and other required components for Node.js native module compilation
+Write-Output "~~~ Installing Visual Studio Build Tools with Node.js native module support..."
+
+# Define components needed for Node.js native module compilation
+$components = @(
+  "Microsoft.VisualStudio.Component.Windows10SDK.$windows10SDKVersion",
+  "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",  # MSVC v143 compiler toolset
+  "Microsoft.VisualStudio.Component.VC.CMake.Project"   # CMake tools for native modules
+)
+
+$argumentList = "--quiet --wait"
+foreach ($component in $components) {
+  $argumentList += " --add $component"
+}
+
+Write-Output "Installing components: $($components -join ', ')"
+
 Start-Process `
   -FilePath $buildToolsPath `
-  -ArgumentList "--quiet --wait --add Microsoft.VisualStudio.Component.Windows10SDK.$windows10SDKVersion" `
+  -ArgumentList $argumentList `
   -NoNewWindow `
   -Wait
 

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -62,7 +62,7 @@ if ($allowedVersions -notcontains $windows10SDKVersion) {
 Write-Output "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
 
 if ($InstallNativeCompilationTools) {
-  Write-Output "Native compilation tools requested. Will also install MSVC compiler toolset and CMake tools."
+  Write-Output "Native compilation tools requested. Will also install MSVC compiler toolset and CMake tools in addition to the Windows 10 SDK."
 } else {
   Write-Output "Installing Windows 10 SDK only. Use -InstallNativeCompilationTools to include MSVC compiler and CMake tools."
 }
@@ -90,7 +90,7 @@ If (-not (Test-Path $buildToolsPath)) {
 
 # Install the Windows SDK and (optionally) native compilation tools
 if ($InstallNativeCompilationTools) {
-  Write-Output "~~~ Installing Visual Studio Build Tools with native compilation tools..."
+  Write-Output "~~~ Installing Visual Studio Build Tools and native compilation tools with Windows 10 sdk..."
 } else {
   Write-Output "~~~ Installing Visual Studio Build Tools with Windows 10 SDK..."
 }

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -38,7 +38,7 @@ $allowedVersions = @(
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (-not (Test-Path $windowsSDKVersionFile)) {
   Write-Output "[!] No Windows 10 SDK version file found at $windowsSDKVersionFile."
-  exit 1
+  Exit 1
 }
 
 $windows10SDKVersion = (Get-Content -TotalCount 1 $windowsSDKVersionFile).Trim()
@@ -46,7 +46,7 @@ $windows10SDKVersion = (Get-Content -TotalCount 1 $windowsSDKVersionFile).Trim()
 if ($windows10SDKVersion -notmatch '^\d+$') {
   Write-Output "[!] Invalid version file format."
   Write-Output "Expected an integer, got: '$windows10SDKVersion'"
-  exit 1
+  Exit 1
 }
 
 if ($allowedVersions -notcontains $windows10SDKVersion) {
@@ -56,7 +56,7 @@ if ($allowedVersions -notcontains $windows10SDKVersion) {
     Write-Output "- $version"
   }
   Write-Output "More info at https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022"
-  exit 1
+  Exit 1
 }
 
 Write-Output "Will attempt to set up Windows 10 ($windows10SDKVersion) SDK and Visual Studio Build Tools..."
@@ -69,7 +69,7 @@ if ($InstallNativeCompilationTools) {
 
 if ($DryRun) {
   Write-Output "Running in dry run mode, finishing here."
-  exit 0
+  Exit 0
 }
 
 # Download the Visual Studio Build Tools Bootstrapper

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -1,13 +1,13 @@
 # Install the Windows 10 SDK and Visual Studio Build Tools using the value in .windows-10-sdk-version.
 #
+# This script installs the Windows 10 SDK by default.
+# Optionally, it can also install native compilation tools for building native modules using the -InstallNativeCompilationTools flag:
+# - MSVC v143 compiler toolset (x64/x86)
+# - CMake tools for Visual Studio
+#
 # The expected .windows-10-sdk-version format is an integer representing a valid SDK component id.
 # The list of valid component ids can be found at
 # https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
-#
-# This script installs the Windows 10 SDK by default.
-# Optionally, it can also install native compilation tools for building native modules:
-# - MSVC v143 compiler toolset (x64/x86)
-# - CMake tools for Visual Studio
 #
 # Example:
 #

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -124,7 +124,7 @@ Write-Output "--- :windows: Checking whether to install Windows 10 SDK..."
 
 if ($SkipWindows10SDKInstallation) {
   Write-Output "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
-  exit 0
+  Exit 0
 }
 
 $windowsSDKVersionFile = ".windows-10-sdk-version"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -107,15 +107,6 @@ if ($developerMode.State -eq 'Enabled') {
   }
 }
 
-Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
-$certificateBinPath = "certificate.bin"
-$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
-  | jq -r '.SecretString' `
-  | Out-File $certificateBinPath
-$certificatePfxPath = "certificate.pfx"
-certutil -decode $certificateBinPath $certificatePfxPath
-Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
-
 Write-Output "--- :windows: Checking whether to install Windows 10 SDK..."
 
 # When using Electron Forge and electron2appx, building Appx requires the Windows 10 SDK
@@ -140,3 +131,12 @@ if (Test-Path $windowsSDKVersionFile) {
 } else {
   Write-Output "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."
 }
+
+Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
+$certificateBinPath = "certificate.bin"
+$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
+  | jq -r '.SecretString' `
+  | Out-File $certificateBinPath
+$certificatePfxPath = "certificate.pfx"
+certutil -decode $certificateBinPath $certificatePfxPath
+Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -28,7 +28,9 @@ $ErrorActionPreference = "Stop"
 
 # Validate parameter combinations
 if ($InstallNativeCompilationTools -and $SkipWindows10SDKInstallation) {
-    throw "Invalid parameter combination: -InstallNativeCompilationTools cannot be used with -SkipWindows10SDKInstallation. Native compilation tools require Windows 10 SDK to be installed."
+    Write-Output "[!] Invalid parameter combination: -InstallNativeCompilationTools cannot be used with -SkipWindows10SDKInstallation."
+    Write-Output "    Native compilation tools require Windows 10 SDK to be installed."
+    Exit 1
 }
 
 Write-Output "--- :windows: Setting up Windows for app distribution"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -107,6 +107,15 @@ if ($developerMode.State -eq 'Enabled') {
   }
 }
 
+Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
+$certificateBinPath = "certificate.bin"
+$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
+  | jq -r '.SecretString' `
+  | Out-File $certificateBinPath
+$certificatePfxPath = "certificate.pfx"
+certutil -decode $certificateBinPath $certificatePfxPath
+Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
+
 Write-Output "--- :windows: Checking whether to install Windows 10 SDK..."
 
 # When using Electron Forge and electron2appx, building Appx requires the Windows 10 SDK
@@ -131,12 +140,3 @@ if (Test-Path $windowsSDKVersionFile) {
 } else {
   Write-Output "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."
 }
-
-Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
-$certificateBinPath = "certificate.bin"
-$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
-  | jq -r '.SecretString' `
-  | Out-File $certificateBinPath
-$certificatePfxPath = "certificate.pfx"
-certutil -decode $certificateBinPath $certificatePfxPath
-Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -157,3 +157,6 @@ if (Test-Path $windowsSDKVersionFile) {
 } else {
   Write-Output "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."
 }
+
+Write-Output "Windows host preparation for app distribution completed successfully."
+Exit 0

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -13,6 +13,7 @@
 # (2) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
 # (3) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
 # (4) Native compilation tools are NOT installed by default. You can install them by calling the script with `-InstallNativeCompilationTools`. This requires the Windows 10 SDK installation to NOT be skipped, as those are installed in tandem.
+# (5) Certificate download can be skipped by setting environment variable `SKIP_CERTIFICATE_DOWNLOAD=true` (useful for testing).
 #
 # Note: In addition to calling this script, and depending on your client app, you might want to also install `npm` and the `Node.js` packages used by your client app on the agent too. For that part, you should use the `automattic/nvm` Buildkite plugin on the pipeline step's `plugins:` attribute.
 #
@@ -114,14 +115,23 @@ if ($developerMode.State -eq 'Enabled') {
   }
 }
 
-Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
-$certificateBinPath = "certificate.bin"
-$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
-  | jq -r '.SecretString' `
-  | Out-File $certificateBinPath
-$certificatePfxPath = "certificate.pfx"
-certutil -decode $certificateBinPath $certificatePfxPath
-Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
+if ($env:SKIP_CERTIFICATE_DOWNLOAD -eq "true") {
+  Write-Output "--- :lock_with_ink_pen: Skipping Code Signing Certificate download"
+} else {
+  Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
+  $certificateBinPath = "certificate.bin"
+  $EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
+    | jq -r '.SecretString' `
+    | Out-File $certificateBinPath
+  $certificatePfxPath = "certificate.pfx"
+  certutil -decode $certificateBinPath $certificatePfxPath
+  Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
+
+  If ($LastExitCode -ne 0) {
+    Write-Output "[!] Failed to download code signing certificate."
+    Exit $LastExitCode
+  }
+}
 
 Write-Output "--- :windows: Checking whether to install Windows 10 SDK..."
 

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -7,17 +7,20 @@
 #  - Enable dev mode so the agent can support Linux-style symlinks
 #  - Download Code Signing Certificates(2)
 #  - Install the Windows 10 SDK if it detected a `.windows-10-sdk-version` file(3)
+#  - Optionally install native compilation tools (MSVC compiler and CMake)(4)
 #
 # (1) Python is NOT installed by default. You can install Python by calling the script with `-InstallPython`.
 # (2) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
 # (3) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
+# (4) Native compilation tools are NOT installed by default. You can install them by calling the script with `-InstallNativeCompilationTools`.
 #
 # Note: In addition to calling this script, and depending on your client app, you might want to also install `npm` and the `Node.js` packages used by your client app on the agent too. For that part, you should use the `automattic/nvm` Buildkite plugin on the pipeline step's `plugins:` attribute.
 #
 
 param (
   [switch]$SkipWindows10SDKInstallation = $false,
-  [switch]$InstallPython = $false
+  [switch]$InstallPython = $false,
+  [switch]$InstallNativeCompilationTools = $false
 )
 
 # Stop script execution when a non-terminating error occurs
@@ -127,7 +130,12 @@ if ($SkipWindows10SDKInstallation) {
 $windowsSDKVersionFile = ".windows-10-sdk-version"
 if (Test-Path $windowsSDKVersionFile) {
   Write-Output "Found $windowsSDKVersionFile file, installing Windows 10 SDK..."
-  & "$PSScriptRoot\install_windows_10_sdk.ps1"
+  
+  if ($InstallNativeCompilationTools) {
+    & "$PSScriptRoot\install_windows_10_sdk.ps1" -InstallNativeCompilationTools
+  } else {
+    & "$PSScriptRoot\install_windows_10_sdk.ps1"
+  }
   If ($LastExitCode -ne 0) { Exit $LastExitCode }
 } else {
   Write-Output "No $windowsSDKVersionFile file found, skipping Windows 10 SDK installation."

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -3,6 +3,7 @@
 #  - Enables long path behavior
 #  - Disable Windows Defender on the CI agent
 #  - Install the "Chocolatey" package manager
+#  - Install Python (required for Node.js native module compilation)
 #  - Enable dev mode so the agent can support Linux-style symlinks
 #  - Download Code Signing Certificates(1)
 #  - Install the Windows 10 SDK if it detected a `.windows-10-sdk-version` file(2)
@@ -73,6 +74,31 @@ if (Test-Path $atpRegPath) {
 Write-Output "--- :windows: Setting up Package Manager"
 $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+
+Write-Output "--- :snake: Installing Python"
+# Install Python 3 via Chocolatey for Node.js native module compilation
+# Many Node.js packages require Python during npm install for building native extensions
+choco install python3 --yes --no-progress
+If ($LastExitCode -ne 0) { 
+  Write-Output "[!] Failed to install Python via Chocolatey"
+  Exit $LastExitCode 
+}
+
+# Refresh environment to make Python available in PATH
+& "$PSScriptRoot\path_aware_refreshenv.ps1"
+If ($LastExitCode -ne 0) { 
+  Write-Output "[!] Failed to refresh environment after Python installation"
+  Exit $LastExitCode 
+}
+
+# Verify Python installation
+$pythonVersion = python --version 2>&1
+If ($LastExitCode -eq 0) {
+  Write-Output "Python installed successfully: $pythonVersion"
+} else {
+  Write-Output "[!] Python installation verification failed"
+  Exit 1
+}
 
 # This should avoid issues with symlinks not being supported in Windows.
 #

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -26,6 +26,11 @@ param (
 # Stop script execution when a non-terminating error occurs
 $ErrorActionPreference = "Stop"
 
+# Validate parameter combinations
+if ($InstallNativeCompilationTools -and $SkipWindows10SDKInstallation) {
+    throw "Invalid parameter combination: -InstallNativeCompilationTools cannot be used with -SkipWindows10SDKInstallation. Native compilation tools require Windows 10 SDK to be installed."
+}
+
 Write-Output "--- :windows: Setting up Windows for app distribution"
 
 Write-Output "Current working directory: $PWD"

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -81,7 +81,7 @@ $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 
 if ($InstallPython) {
-  Write-Output "Run with InstallPython = true. Installing Python..."
+  Write-Output "Run with InstallPython = true. Installing Python for Node.js native module compilation..."
   & "$PSScriptRoot\install_python.ps1"
   If ($LastExitCode -ne 0) { Exit $LastExitCode }
 } else {

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -12,7 +12,7 @@
 # (1) Python is NOT installed by default. You can install Python by calling the script with `-InstallPython`.
 # (2) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
 # (3) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
-# (4) Native compilation tools are NOT installed by default. You can install them by calling the script with `-InstallNativeCompilationTools`.
+# (4) Native compilation tools are NOT installed by default. You can install them by calling the script with `-InstallNativeCompilationTools`. This requires the Windows 10 SDK installation to NOT be skipped, as those are installed in tandem.
 #
 # Note: In addition to calling this script, and depending on your client app, you might want to also install `npm` and the `Node.js` packages used by your client app on the agent too. For that part, you should use the `automattic/nvm` Buildkite plugin on the pipeline step's `plugins:` attribute.
 #

--- a/bin/prepare_windows_host_for_app_distribution.ps1
+++ b/bin/prepare_windows_host_for_app_distribution.ps1
@@ -3,19 +3,21 @@
 #  - Enables long path behavior
 #  - Disable Windows Defender on the CI agent
 #  - Install the "Chocolatey" package manager
-#  - Install Python (required for Node.js native module compilation)
+#  - Install Python (required for Node.js native module compilation)(1)
 #  - Enable dev mode so the agent can support Linux-style symlinks
-#  - Download Code Signing Certificates(1)
-#  - Install the Windows 10 SDK if it detected a `.windows-10-sdk-version` file(2)
+#  - Download Code Signing Certificates(2)
+#  - Install the Windows 10 SDK if it detected a `.windows-10-sdk-version` file(3)
 #
-# (1) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
-# (2) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
+# (1) Python is NOT installed by default. You can install Python by calling the script with `-InstallPython`.
+# (2) The certificate it installs is stored in our AWS SecretsManager storage (`windows-code-signing-certificate` secret ID)
+# (3) You can skip the Windows 10 SDK installation regardless of whether `.windows-10-sdk-version` is present by calling the script with `-SkipWindows10SDKInstallation`.
 #
 # Note: In addition to calling this script, and depending on your client app, you might want to also install `npm` and the `Node.js` packages used by your client app on the agent too. For that part, you should use the `automattic/nvm` Buildkite plugin on the pipeline step's `plugins:` attribute.
 #
 
 param (
-  [switch]$SkipWindows10SDKInstallation = $false
+  [switch]$SkipWindows10SDKInstallation = $false,
+  [switch]$InstallPython = $false
 )
 
 # Stop script execution when a non-terminating error occurs
@@ -75,29 +77,12 @@ Write-Output "--- :windows: Setting up Package Manager"
 $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 
-Write-Output "--- :snake: Installing Python"
-# Install Python 3 via Chocolatey for Node.js native module compilation
-# Many Node.js packages require Python during npm install for building native extensions
-choco install python3 --yes --no-progress
-If ($LastExitCode -ne 0) { 
-  Write-Output "[!] Failed to install Python via Chocolatey"
-  Exit $LastExitCode 
-}
-
-# Refresh environment to make Python available in PATH
-& "$PSScriptRoot\path_aware_refreshenv.ps1"
-If ($LastExitCode -ne 0) { 
-  Write-Output "[!] Failed to refresh environment after Python installation"
-  Exit $LastExitCode 
-}
-
-# Verify Python installation
-$pythonVersion = python --version 2>&1
-If ($LastExitCode -eq 0) {
-  Write-Output "Python installed successfully: $pythonVersion"
+if ($InstallPython) {
+  Write-Output "Run with InstallPython = true. Installing Python..."
+  & "$PSScriptRoot\install_python.ps1"
+  If ($LastExitCode -ne 0) { Exit $LastExitCode }
 } else {
-  Write-Output "[!] Python installation verification failed"
-  Exit 1
+  Write-Output "Python installation not requested. Skipping Python installation."
 }
 
 # This should avoid issues with symlinks not being supported in Windows.

--- a/tests/test_install_python.ps1
+++ b/tests/test_install_python.ps1
@@ -12,7 +12,7 @@ Write-Output "Running $($MyInvocation.MyCommand.Name) with ExpectedExitCode=$Exp
 
 if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
   Write-Output "$emojiRedCross Expected call to succeed (expected error code = 0), but given an error keyphrase to check."
-  exit 1
+  Exit 1
 }
 
 $output = & "$PSScriptRoot\..\bin\install_python.ps1" -DryRun
@@ -22,20 +22,20 @@ if ($exitCode -ne $ExpectedExitCode) {
   Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
   Write-Output "Output was:"
   Write-Output "$output"
-  exit 1
+  Exit 1
 } else {
   Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
 }
 
 # Only check error keyphrase if exit code is not 0
 if ($exitCode -eq 0) {
-  exit 0
+  Exit 0
 }
 
 # If keyphrase is empty, assume the caller is satisfied with only testing the exit code
 if ($ExpectedErrorKeyphrase -eq "") {
   Write-Output "Exit code match expectation and no error keyphrase was provided. Test completed."
-  exit 0
+  Exit 0
 }
 
 if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
@@ -44,5 +44,5 @@ if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
 } else {
   Write-Output "$emojiRedCross Expected error to contain '$ExpectedErrorKeyphrase', but got:"
   Write-Output "$output"
-  exit 1
+  Exit 1
 }

--- a/tests/test_install_python.ps1
+++ b/tests/test_install_python.ps1
@@ -1,0 +1,48 @@
+param (
+  [int]$ExpectedExitCode = 0,
+  [string]$ExpectedErrorKeyphrase = ""
+)
+
+# Ensure the output is UTF-8 encoded so we can use emojis...
+[System.Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$emojiGreenCheck = "$([char]0x2705)"
+$emojiRedCross = "$([char]0x274C)"
+
+Write-Output "Running $($MyInvocation.MyCommand.Name) with ExpectedExitCode=$ExpectedExitCode and ExpectedErrorKeyphrase=$ExpectedErrorKeyphrase"
+
+if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
+  Write-Output "$emojiRedCross Expected call to succeed (expected error code = 0), but given an error keyphrase to check."
+  exit 1
+}
+
+$output = & "$PSScriptRoot\..\bin\install_python.ps1" -DryRun
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
+  exit 1
+} else {
+  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
+}
+
+# Only check error keyphrase if exit code is not 0
+if ($exitCode -eq 0) {
+  exit 0
+}
+
+# If keyphrase is empty, assume the caller is satisfied with only testing the exit code
+if ($ExpectedErrorKeyphrase -eq "") {
+  Write-Output "Exit code match expectation and no error keyphrase was provided. Test completed."
+  exit 0
+}
+
+if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
+  Write-Output "$emojiGreenCheck Error keyphrase matches expected value ($ExpectedErrorKeyphrase)"
+  Write-Output "Test completed."
+} else {
+  Write-Output "$emojiRedCross Expected error to contain '$ExpectedErrorKeyphrase', but got:"
+  Write-Output "$output"
+  exit 1
+}

--- a/tests/test_install_windows_10_sdk.ps1
+++ b/tests/test_install_windows_10_sdk.ps1
@@ -12,7 +12,7 @@ Write-Output "Running $($MyInvocation.MyCommand.Name) with ExpectedExitCode=$Exp
 
 if (($ExpectedExitCode -eq 0) -and ($ExpectedErrorKeyphrase -ne "")) {
   Write-Output "$emojiRedCross Expected call to succeed (expected error code = 0), but given an error keyphrase to check."
-  exit 1
+  Exit 1
 }
 
 $output = & "$PSScriptRoot\..\bin\install_windows_10_sdk.ps1" -DryRun
@@ -22,20 +22,20 @@ if ($exitCode -ne $ExpectedExitCode) {
   Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
   Write-Output "Output was:"
   Write-Output "$output"
-  exit 1
+  Exit 1
 } else {
   Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
 }
 
 # Only check error keyphrase if exit code is not 0
 if ($exitCode -eq 0) {
-  exit 0
+  Exit 0
 }
 
 # If keyphrase is empty, assume the caller is satisfied with only testing the exit code
 if ($ExpectedErrorKeyphrase -eq "") {
   Write-Output "Exit code match expectation and no error keyphrase was provided. Test completed."
-  exit 0
+  Exit 0
 }
 
 if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
@@ -44,5 +44,5 @@ if ($output -match [regex]::Escape($ExpectedErrorKeyphrase)) {
 } else {
   Write-Output "$emojiRedCross Expected error to contain '$ExpectedErrorKeyphrase', but got:"
   Write-Output "$output"
-  exit 1
+  Exit 1
 }

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -1,6 +1,7 @@
-# Tests the prepare_windows_host_for_app_distribution.ps1 script with the -SkipWindows10SDKInstallation parameter.
+# Tests the prepare_windows_host_for_app_distribution.ps1 script with installation parameters.
 #
-# We only test the skip behavior because the installation takes a "long" time to run.
+# We only test the skip behavior and explicit installation requests because the installations take a "long" time to run.
+# Tests both -InstallPython and -SkipWindows10SDKInstallation parameters.
 
 param (
   [int]$ExpectedExitCode = 0
@@ -11,38 +12,72 @@ param (
 $emojiGreenCheck = "$([char]0x2705)"
 $emojiRedCross = "$([char]0x274C)"
 
-Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with -SkipWindows10SDKInstallation"
-
-# Create a valid SDK version file to ensure it's not being used
-$sdkVersion = "20348"
-"$sdkVersion" | Out-File .windows-10-sdk-version
-
-# Run the script with skip parameter
-$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation
-$exitCode = $LASTEXITCODE
-
-# Check exit code
-if ($exitCode -ne $ExpectedExitCode) {
-  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
-  Write-Output "Output was:"
-  Write-Output "$output"
-  exit 1
-} else {
-  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
+function Test-ScriptWithParameters {
+  param(
+    [string]$TestName,
+    [string[]]$Parameters,
+    [string[]]$ExpectedMessages
+  )
+  
+  Write-Output ""
+  Write-Output "=== Testing $TestName ==="
+  
+  # Create a valid SDK version file to ensure it's not being used when skipped
+  $sdkVersion = "20348"
+  "$sdkVersion" | Out-File .windows-10-sdk-version
+  
+  # Run the script with specified parameters
+  $paramString = $Parameters -join " "
+  Write-Output "Running: prepare_windows_host_for_app_distribution.ps1 $paramString"
+  
+  $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" @Parameters
+  $exitCode = $LASTEXITCODE
+  
+  # Check exit code
+  if ($exitCode -ne $ExpectedExitCode) {
+    Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
+    Write-Output "Output was:"
+    Write-Output "$output"
+    exit 1
+  } else {
+    Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
+  }
+  
+  # Check for expected messages
+  foreach ($expectedMessage in $ExpectedMessages) {
+    if ($output -match [regex]::Escape($expectedMessage)) {
+      Write-Output "$emojiGreenCheck Found expected message: '$expectedMessage'"
+    } else {
+      Write-Output "$emojiRedCross Expected to find message: '$expectedMessage'"
+      Write-Output "Full output was:"
+      Write-Output "$output"
+      exit 1
+    }
+  }
+  
+  Write-Output "$emojiGreenCheck $TestName completed successfully"
 }
 
-$expectedSkipMessage = "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
-if ($output -match [regex]::Escape($expectedSkipMessage)) {
-  Write-Output "$emojiGreenCheck Found expected skip message in output"
-} else {
-  Write-Output "$emojiRedCross Expected to find message about skipping due to parameter, but got:"
-  Write-Output "$output"
-  exit 1
-}
+# Test 1: Default behavior - no Python installation, skip Windows 10 SDK for testing
+Test-ScriptWithParameters -TestName "Default Behavior (No Python, Skip SDK)" `
+  -Parameters @("-SkipWindows10SDKInstallation") `
+  -ExpectedMessages @(
+    "Python installation not requested. Skipping Python installation.",
+    "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+  )
 
-# Verify SDK was not installed by checking the file system
+# Test 2: Explicitly install Python, skip Windows 10 SDK for testing
+Test-ScriptWithParameters -TestName "Install Python (Skip SDK)" `
+  -Parameters @("-SkipWindows10SDKInstallation", "-InstallPython") `
+  -ExpectedMessages @(
+    "Run with InstallPython = true. Installing Python for Node.js native module compilation...",
+    "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+  )
+
+# Additional verification: Ensure SDK was not installed when skipped
 $windowsSDKsRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
-$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion\x64"
+$sdkVersion = "20348"
+$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion.0\x64"
 If (Test-Path $sdkPath) {
   Write-Output "$emojiRedCross Found SDK installation at $sdkPath when it should have been skipped"
   exit 1
@@ -50,4 +85,5 @@ If (Test-Path $sdkPath) {
   Write-Output "$emojiGreenCheck Confirmed SDK was not installed at $sdkPath"
 }
 
-Write-Output "Test completed successfully."
+Write-Output ""
+Write-Output "$emojiGreenCheck All tests completed successfully."

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -21,6 +21,9 @@ param (
 $emojiGreenCheck = "$([char]0x2705)"
 $emojiRedCross = "$([char]0x274C)"
 
+# Skip certificate download for all tests to avoid AWS credential issues
+$env:SKIP_CERTIFICATE_DOWNLOAD = "true"
+
 Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with various parameter combinations"
 
 # Function to clean up test files
@@ -95,11 +98,6 @@ if ($output -match "Invalid parameter combination") {
 Write-Output "`n--- Test 3: No SDK version file with native compilation tools requested"
 Remove-TestFiles
 
-# Ensure no SDK version file exists
-if (Test-Path ".windows-10-sdk-version") {
-  Remove-Item ".windows-10-sdk-version" -Force
-}
-
 $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools 2>&1
 $exitCode = $LASTEXITCODE
 
@@ -124,11 +122,6 @@ if ($output -match [regex]::Escape($expectedNoFileSkipMessage)) {
 # Test 4: No .windows-10-sdk-version file without -InstallNativeCompilationTools (should skip everything)
 Write-Output "`n--- Test 4: No SDK version file and no native tools requested"
 Remove-TestFiles
-
-# Ensure no SDK version file exists
-if (Test-Path ".windows-10-sdk-version") {
-  Remove-Item ".windows-10-sdk-version" -Force
-}
 
 $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1"
 $exitCode = $LASTEXITCODE

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -1,7 +1,6 @@
-# Tests the prepare_windows_host_for_app_distribution.ps1 script with installation parameters.
+# Tests the prepare_windows_host_for_app_distribution.ps1 script with the -SkipWindows10SDKInstallation parameter.
 #
-# We only test the skip behavior and explicit installation requests because the installations take a "long" time to run.
-# Tests both -InstallPython and -SkipWindows10SDKInstallation parameters.
+# We only test the skip behavior because the installation takes a "long" time to run.
 
 param (
   [int]$ExpectedExitCode = 0
@@ -12,78 +11,53 @@ param (
 $emojiGreenCheck = "$([char]0x2705)"
 $emojiRedCross = "$([char]0x274C)"
 
-function Test-ScriptWithParameters {
-  param(
-    [string]$TestName,
-    [string[]]$Parameters,
-    [string[]]$ExpectedMessages
-  )
-  
-  Write-Output ""
-  Write-Output "=== Testing $TestName ==="
-  
-  # Create a valid SDK version file to ensure it's not being used when skipped
-  $sdkVersion = "20348"
-  "$sdkVersion" | Out-File .windows-10-sdk-version
-  
-  # Run the script with specified parameters
-  $paramString = $Parameters -join " "
-  Write-Output "Running: prepare_windows_host_for_app_distribution.ps1 $paramString"
-  
-  $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" @Parameters
-  $exitCode = $LASTEXITCODE
-  
-  # Check exit code
-  if ($exitCode -ne $ExpectedExitCode) {
-    Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
-    Write-Output "Output was:"
-    Write-Output "$output"
-    exit 1
-  } else {
-    Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
-  }
-  
-  # Check for expected messages
-  foreach ($expectedMessage in $ExpectedMessages) {
-    if ($output -match [regex]::Escape($expectedMessage)) {
-      Write-Output "$emojiGreenCheck Found expected message: '$expectedMessage'"
-    } else {
-      Write-Output "$emojiRedCross Expected to find message: '$expectedMessage'"
-      Write-Output "Full output was:"
-      Write-Output "$output"
-      exit 1
-    }
-  }
-  
-  Write-Output "$emojiGreenCheck $TestName completed successfully"
+Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with -SkipWindows10SDKInstallation"
+
+# Create a valid SDK version file to ensure it's not being used
+$sdkVersion = "20348"
+"$sdkVersion" | Out-File .windows-10-sdk-version
+
+# Run the script with skip parameter
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation
+$exitCode = $LASTEXITCODE
+
+# Check exit code
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
+  Exit 1
+} else {
+  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
 }
 
-# Test 1: Default behavior - no Python installation, skip Windows 10 SDK for testing
-Test-ScriptWithParameters -TestName "Default Behavior (No Python, Skip SDK)" `
-  -Parameters @("-SkipWindows10SDKInstallation") `
-  -ExpectedMessages @(
-    "Python installation not requested. Skipping Python installation.",
-    "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
-  )
+$expectedSkipMessage = "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+if ($output -match [regex]::Escape($expectedSkipMessage)) {
+  Write-Output "$emojiGreenCheck Found expected skip message in output"
+} else {
+  Write-Output "$emojiRedCross Expected to find message about skipping due to parameter, but got:"
+  Write-Output "$output"
+  Exit 1
+}
 
-# Test 2: Explicitly install Python, skip Windows 10 SDK for testing
-Test-ScriptWithParameters -TestName "Install Python (Skip SDK)" `
-  -Parameters @("-SkipWindows10SDKInstallation", "-InstallPython") `
-  -ExpectedMessages @(
-    "Run with InstallPython = true. Installing Python for Node.js native module compilation...",
-    "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
-  )
-
-# Additional verification: Ensure SDK was not installed when skipped
+# Verify SDK was not installed by checking the file system
 $windowsSDKsRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
-$sdkVersion = "20348"
-$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion.0\x64"
+$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion\x64"
 If (Test-Path $sdkPath) {
   Write-Output "$emojiRedCross Found SDK installation at $sdkPath when it should have been skipped"
-  exit 1
+  Exit 1
 } else {
   Write-Output "$emojiGreenCheck Confirmed SDK was not installed at $sdkPath"
 }
 
-Write-Output ""
-Write-Output "$emojiGreenCheck All tests completed successfully."
+# Test Python installation skip behavior (default case when -InstallPython is not used)
+$expectedPythonSkipMessage = "Python installation not requested. Skipping Python installation."
+if ($output -match [regex]::Escape($expectedPythonSkipMessage)) {
+  Write-Output "$emojiGreenCheck Found expected Python skip message in output"
+} else {
+  Write-Output "$emojiRedCross Expected to find message about skipping Python installation, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+Write-Output "Test completed successfully."

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -5,12 +5,9 @@
 # 2. -SkipWindows10SDKInstallation -InstallNativeCompilationTools (should fail with validation error)
 # 3. No .windows-10-sdk-version file with -InstallNativeCompilationTools (should skip installation - no version file available)
 # 4. No .windows-10-sdk-version file without -InstallNativeCompilationTools (should skip installation)
-# 5. .windows-10-sdk-version file exists with -InstallNativeCompilationTools (should install SDK with native tools)
-# 6. .windows-10-sdk-version file exists without -InstallNativeCompilationTools (should install SDK only)
-# 7. -InstallPython flag (should attempt Python installation)
 #
-# Note: For tests involving actual downloads/installations, we test up to the download attempt
-# to verify the correct decision logic without requiring network access or long installations.
+# Note: These tests focus on parameter validation and decision logic only, without performing
+# expensive installations or downloads.
 
 param (
   [int]$ExpectedExitCode = 0
@@ -144,79 +141,7 @@ if ($output -match [regex]::Escape($expectedNoFileSkipMessage)) {
   Exit 1
 }
 
-# Test 5: .windows-10-sdk-version file exists with -InstallNativeCompilationTools (should install SDK with native tools)
-Write-Output "`n--- Test 5: SDK version file exists with native compilation tools requested"
-Remove-TestFiles
-
-# Create a valid SDK version file
-"$sdkVersion" | Out-File .windows-10-sdk-version
-
-$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools 2>&1
-$exitCode = $LASTEXITCODE
-
-$expectedSDKMessage = "Found .windows-10-sdk-version file"
-if ($output -match [regex]::Escape($expectedSDKMessage)) {
-  Write-Output "$emojiGreenCheck Test 5: Found expected SDK installation message"
-} else {
-  Write-Output "$emojiRedCross Test 5: Expected to find SDK installation message, but got:"
-  Write-Output "$output"
-  Exit 1
-}
-
-# Test 6: .windows-10-sdk-version file exists without -InstallNativeCompilationTools (should install SDK only)
-Write-Output "`n--- Test 6: SDK version file exists without native compilation tools"
-Remove-TestFiles
-
-# Create a valid SDK version file
-"$sdkVersion" | Out-File .windows-10-sdk-version
-
-$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" 2>&1
-$exitCode = $LASTEXITCODE
-
-$expectedSDKMessage = "Found .windows-10-sdk-version file"
-if ($output -match [regex]::Escape($expectedSDKMessage)) {
-  Write-Output "$emojiGreenCheck Test 6: Found expected SDK installation message"
-} else {
-  Write-Output "$emojiRedCross Test 6: Expected to find SDK installation message, but got:"
-  Write-Output "$output"
-  Exit 1
-}
-
-# Test 7: -InstallPython flag (should attempt Python installation)
-Write-Output "`n--- Test 7: Python installation requested"
-Remove-TestFiles
-
-$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallPython 2>&1
-$exitCode = $LASTEXITCODE
-
-$expectedPythonInstallMessage = "Installing Python for Node.js native module compilation"
-if ($output -match [regex]::Escape($expectedPythonInstallMessage)) {
-  Write-Output "$emojiGreenCheck Test 7: Found expected Python installation message"
-} else {
-  Write-Output "$emojiRedCross Test 7: Expected to find Python installation message, but got:"
-  Write-Output "$output"
-  Exit 1
-}
-
-# Test Python installation skip behavior (should be consistent across tests that don't use -InstallPython)
-Write-Output "`n--- Testing Python installation skip behavior"
-# Use output from Test 4 since it completed successfully without errors
-$expectedPythonSkipMessage = "Skipping Python installation"
-# We'll test this on a fresh run since it ran without -InstallPython
-Remove-TestFiles
-"$sdkVersion" | Out-File .windows-10-sdk-version
-$outputForPythonTest = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" 2>&1
-
-if ($outputForPythonTest -match [regex]::Escape($expectedPythonSkipMessage)) {
-  Write-Output "$emojiGreenCheck Found expected Python skip message in output"
-} else {
-  Write-Output "$emojiRedCross Expected to find message about skipping Python installation, but got:"
-  Write-Output "$outputForPythonTest"
-  Exit 1
-}
-
 # Clean up
 Remove-TestFiles
 
 Write-Output "`n$emojiGreenCheck All tests completed successfully."
-Write-Output "Note: Tests 5, 6, and 7 may attempt to call install_windows_10_sdk.ps1 or install_python.ps1 which require network access. If these fail due to network issues, the validation logic is still confirmed working."

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -1,6 +1,16 @@
-# Tests the prepare_windows_host_for_app_distribution.ps1 script with the -SkipWindows10SDKInstallation parameter.
+# Tests the prepare_windows_host_for_app_distribution.ps1 script with various parameter combinations.
 #
-# We only test the skip behavior because the installation takes a "long" time to run.
+# This test covers multiple scenarios:
+# 1. -SkipWindows10SDKInstallation (should skip SDK installation check entirely)
+# 2. -SkipWindows10SDKInstallation -InstallNativeCompilationTools (should fail with validation error)
+# 3. No .windows-10-sdk-version file with -InstallNativeCompilationTools (should skip installation - no version file available)
+# 4. No .windows-10-sdk-version file without -InstallNativeCompilationTools (should skip installation)
+# 5. .windows-10-sdk-version file exists with -InstallNativeCompilationTools (should install SDK with native tools)
+# 6. .windows-10-sdk-version file exists without -InstallNativeCompilationTools (should install SDK only)
+# 7. -InstallPython flag (should attempt Python installation)
+#
+# Note: For tests involving actual downloads/installations, we test up to the download attempt
+# to verify the correct decision logic without requiring network access or long installations.
 
 param (
   [int]$ExpectedExitCode = 0
@@ -11,53 +21,209 @@ param (
 $emojiGreenCheck = "$([char]0x2705)"
 $emojiRedCross = "$([char]0x274C)"
 
-Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with -SkipWindows10SDKInstallation"
+Write-Output "Testing prepare_windows_host_for_app_distribution.ps1 with various parameter combinations"
 
-# Create a valid SDK version file to ensure it's not being used
+# Function to clean up test files
+function Remove-TestFiles {
+  if (Test-Path ".windows-10-sdk-version") {
+    Remove-Item ".windows-10-sdk-version" -Force
+  }
+  if (Test-Path "vs_buildtools.exe") {
+    Remove-Item "vs_buildtools.exe" -Force
+  }
+}
+
+# Test 1: -SkipWindows10SDKInstallation (should skip both SDK and native tools)
+Write-Output "`n--- Test 1: Skip SDK installation without native tools"
+Remove-TestFiles
+
+# Create a valid SDK version file to ensure it's not being used when skip is set
 $sdkVersion = "20348"
 "$sdkVersion" | Out-File .windows-10-sdk-version
 
-# Run the script with skip parameter
 $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation
 $exitCode = $LASTEXITCODE
 
-# Check exit code
 if ($exitCode -ne $ExpectedExitCode) {
-  Write-Output "$emojiRedCross Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "$emojiRedCross Test 1: Expected exit code $ExpectedExitCode, got $exitCode"
   Write-Output "Output was:"
   Write-Output "$output"
   Exit 1
 } else {
-  Write-Output "$emojiGreenCheck Exit code matches expected value ($ExpectedExitCode)"
+  Write-Output "$emojiGreenCheck Test 1: Exit code matches expected value ($ExpectedExitCode)"
 }
 
-$expectedSkipMessage = "Run with SkipWindows10SDKInstallation = true. Skipping Windows 10 SDK installation check."
+$expectedSkipMessage = "Skipping Windows 10 SDK installation check"
 if ($output -match [regex]::Escape($expectedSkipMessage)) {
-  Write-Output "$emojiGreenCheck Found expected skip message in output"
+  Write-Output "$emojiGreenCheck Test 1: Found expected skip message in output"
 } else {
-  Write-Output "$emojiRedCross Expected to find message about skipping due to parameter, but got:"
+  Write-Output "$emojiRedCross Test 1: Expected to find skip message, but got:"
   Write-Output "$output"
   Exit 1
 }
 
-# Verify SDK was not installed by checking the file system
-$windowsSDKsRoot = "C:\Program Files (x86)\Windows Kits\10\bin"
-$sdkPath = "$windowsSDKsRoot\10.0.$sdkVersion\x64"
-If (Test-Path $sdkPath) {
-  Write-Output "$emojiRedCross Found SDK installation at $sdkPath when it should have been skipped"
+# Test 2: -SkipWindows10SDKInstallation -InstallNativeCompilationTools (should fail with validation error)
+Write-Output "`n--- Test 2: Invalid parameter combination - skip SDK but attempt native compilation tools"
+Remove-TestFiles
+
+# Create a valid SDK version file (irrelevant since validation should fail before processing)
+"$sdkVersion" | Out-File .windows-10-sdk-version
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation -InstallNativeCompilationTools 2>&1
+$exitCode = $LASTEXITCODE
+
+# Expect the script to fail with a validation error (non-zero exit code)
+if ($exitCode -eq 0) {
+  Write-Output "$emojiRedCross Test 2: Expected script to fail with validation error, but it succeeded with exit code $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
   Exit 1
 } else {
-  Write-Output "$emojiGreenCheck Confirmed SDK was not installed at $sdkPath"
+  Write-Output "$emojiGreenCheck Test 2: Script correctly failed with validation error (exit code $exitCode)"
 }
 
-# Test Python installation skip behavior (default case when -InstallPython is not used)
-$expectedPythonSkipMessage = "Python installation not requested. Skipping Python installation."
-if ($output -match [regex]::Escape($expectedPythonSkipMessage)) {
+# Check for our validation error message
+if ($output -match "Invalid parameter combination") {
+  Write-Output "$emojiGreenCheck Test 2: Found expected validation error message"
+} else {
+  Write-Output "$emojiRedCross Test 2: Expected validation error not found. Output:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test 3: No .windows-10-sdk-version file with -InstallNativeCompilationTools (should skip installation)
+Write-Output "`n--- Test 3: No SDK version file with native compilation tools requested"
+Remove-TestFiles
+
+# Ensure no SDK version file exists
+if (Test-Path ".windows-10-sdk-version") {
+  Remove-Item ".windows-10-sdk-version" -Force
+}
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools 2>&1
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Output "$emojiRedCross Test 3: Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
+  Exit 1
+} else {
+  Write-Output "$emojiGreenCheck Test 3: Exit code matches expected value ($ExpectedExitCode)"
+}
+
+$expectedNoFileSkipMessage = "No .windows-10-sdk-version file found"
+if ($output -match [regex]::Escape($expectedNoFileSkipMessage)) {
+  Write-Output "$emojiGreenCheck Test 3: Found expected skip message when no version file exists"
+} else {
+  Write-Output "$emojiRedCross Test 3: Expected to find skip message, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test 4: No .windows-10-sdk-version file without -InstallNativeCompilationTools (should skip everything)
+Write-Output "`n--- Test 4: No SDK version file and no native tools requested"
+Remove-TestFiles
+
+# Ensure no SDK version file exists
+if (Test-Path ".windows-10-sdk-version") {
+  Remove-Item ".windows-10-sdk-version" -Force
+}
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1"
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne $ExpectedExitCode) {
+  Write-Output "$emojiRedCross Test 4: Expected exit code $ExpectedExitCode, got $exitCode"
+  Write-Output "Output was:"
+  Write-Output "$output"
+  Exit 1
+} else {
+  Write-Output "$emojiGreenCheck Test 4: Exit code matches expected value ($ExpectedExitCode)"
+}
+
+$expectedNoFileSkipMessage = "No .windows-10-sdk-version file found"
+if ($output -match [regex]::Escape($expectedNoFileSkipMessage)) {
+  Write-Output "$emojiGreenCheck Test 4: Found expected no-file skip message"
+} else {
+  Write-Output "$emojiRedCross Test 4: Expected to find no-file skip message, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test 5: .windows-10-sdk-version file exists with -InstallNativeCompilationTools (should install SDK with native tools)
+Write-Output "`n--- Test 5: SDK version file exists with native compilation tools requested"
+Remove-TestFiles
+
+# Create a valid SDK version file
+"$sdkVersion" | Out-File .windows-10-sdk-version
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools 2>&1
+$exitCode = $LASTEXITCODE
+
+$expectedSDKMessage = "Found .windows-10-sdk-version file"
+if ($output -match [regex]::Escape($expectedSDKMessage)) {
+  Write-Output "$emojiGreenCheck Test 5: Found expected SDK installation message"
+} else {
+  Write-Output "$emojiRedCross Test 5: Expected to find SDK installation message, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test 6: .windows-10-sdk-version file exists without -InstallNativeCompilationTools (should install SDK only)
+Write-Output "`n--- Test 6: SDK version file exists without native compilation tools"
+Remove-TestFiles
+
+# Create a valid SDK version file
+"$sdkVersion" | Out-File .windows-10-sdk-version
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" 2>&1
+$exitCode = $LASTEXITCODE
+
+$expectedSDKMessage = "Found .windows-10-sdk-version file"
+if ($output -match [regex]::Escape($expectedSDKMessage)) {
+  Write-Output "$emojiGreenCheck Test 6: Found expected SDK installation message"
+} else {
+  Write-Output "$emojiRedCross Test 6: Expected to find SDK installation message, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test 7: -InstallPython flag (should attempt Python installation)
+Write-Output "`n--- Test 7: Python installation requested"
+Remove-TestFiles
+
+$output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -InstallPython 2>&1
+$exitCode = $LASTEXITCODE
+
+$expectedPythonInstallMessage = "Installing Python for Node.js native module compilation"
+if ($output -match [regex]::Escape($expectedPythonInstallMessage)) {
+  Write-Output "$emojiGreenCheck Test 7: Found expected Python installation message"
+} else {
+  Write-Output "$emojiRedCross Test 7: Expected to find Python installation message, but got:"
+  Write-Output "$output"
+  Exit 1
+}
+
+# Test Python installation skip behavior (should be consistent across tests that don't use -InstallPython)
+Write-Output "`n--- Testing Python installation skip behavior"
+# Use output from Test 4 since it completed successfully without errors
+$expectedPythonSkipMessage = "Skipping Python installation"
+# We'll test this on a fresh run since it ran without -InstallPython
+Remove-TestFiles
+"$sdkVersion" | Out-File .windows-10-sdk-version
+$outputForPythonTest = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" 2>&1
+
+if ($outputForPythonTest -match [regex]::Escape($expectedPythonSkipMessage)) {
   Write-Output "$emojiGreenCheck Found expected Python skip message in output"
 } else {
   Write-Output "$emojiRedCross Expected to find message about skipping Python installation, but got:"
-  Write-Output "$output"
+  Write-Output "$outputForPythonTest"
   Exit 1
 }
 
-Write-Output "Test completed successfully."
+# Clean up
+Remove-TestFiles
+
+Write-Output "`n$emojiGreenCheck All tests completed successfully."
+Write-Output "Note: Tests 5, 6, and 7 may attempt to call install_windows_10_sdk.ps1 or install_python.ps1 which require network access. If these fail due to network issues, the validation logic is still confirmed working."


### PR DESCRIPTION
To fix the error seen in https://github.com/Automattic/studio/pull/1594 ([build](https://github.com/Automattic/studio/pull/1594)), this PR implemented:
- Python installation during the Windows setup so that it can be used by npm install scripts
- Addition of native compilation components to Visual Studio Build Tools

Being tested via https://github.com/Automattic/studio/pull/1608

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
