### PR TITLE
Prepare for release 5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Install Python during windows setup and install additional Visual Studio Build Tools components for native builds [#186]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 5.5.0
+
+### New Features
+
+- Install Python during windows setup and install additional Visual Studio Build Tools components for native builds [#186]
 
 ## 5.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _None._
 
 ### New Features
 
-- Install Python during windows setup and install additional Visual Studio Build Tools components for native builds [#186]
+- Allow optionally installing Python and additional Visual Studio Build Tools components for native builds during Windows setup [#186]
 
 ## 5.4.0
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#5.4.0:
+      - automattic/a8c-ci-toolkit#5.5.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `5.4.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `5.5.0`.
 
 ## Configuration
 


### PR DESCRIPTION
```
## 5.5.0

### New Features

- Install Python during windows setup and install additional Visual Studio Build Tools components for native builds [#186]
```

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
