### PR TITLE
Only use Windows SDK 19041

### DIFF
--- a/.buildkite/pipeline-windows-tests.yml
+++ b/.buildkite/pipeline-windows-tests.yml
@@ -16,7 +16,7 @@ steps:
     steps:
       - label: ":windows: install_windows_10_sdk Tests - Version file with valid format and version"
         command: |
-          "20348" | Out-File .windows-10-sdk-version
+          "19041" | Out-File .windows-10-sdk-version
           .\tests\test_install_windows_10_sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -26,7 +26,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with one new line"
         command: |
-          "20348`n" | Out-File .windows-10-sdk-version
+          "19041`n" | Out-File .windows-10-sdk-version
           .\tests\test_install_windows_10_sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -36,7 +36,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with more than one new line"
         command: |
-          "20348`n`n" | Out-File .windows-10-sdk-version
+          "19041`n`n" | Out-File .windows-10-sdk-version
           .\tests\test_install_windows_10_sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows
@@ -56,7 +56,7 @@ steps:
 
       - label: ":windows: install_windows_10_sdk Tests - Version file with trailing whitespaces"
         command: |
-          "18362   " | Out-File .windows-10-sdk-version
+          "19041   " | Out-File .windows-10-sdk-version
           .\tests\test_install_windows_10_sdk.ps1 -ExpectedExitCode 0
         agents:
           queue: windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Windows 10 SDKs are now limited to version 19041 due to availability from Microsoft. [#188]
 
 ## 5.5.0
 

--- a/bin/install_windows_10_sdk.ps1
+++ b/bin/install_windows_10_sdk.ps1
@@ -11,7 +11,7 @@
 #
 # Example:
 #
-#   20348
+#   19041
 
 param (
   [switch]$DryRun = $false,
@@ -25,14 +25,7 @@ Write-Output "--- :windows: Installing Windows 10 SDK and Visual Studio Build To
 
 # See list at https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
 $allowedVersions = @(
-  "20348",
-  "19041",
-  "18362",
-  "17763",
-  "17134",
-  "16299",
-  "15063",
-  "14393"
+  "19041"
 )
 
 $windowsSDKVersionFile = ".windows-10-sdk-version"

--- a/tests/test_prepare_windows_host_for_app_distribution.ps1
+++ b/tests/test_prepare_windows_host_for_app_distribution.ps1
@@ -38,7 +38,7 @@ Write-Output "`n--- Test 1: Skip SDK installation without native tools"
 Remove-TestFiles
 
 # Create a valid SDK version file to ensure it's not being used when skip is set
-$sdkVersion = "20348"
+$sdkVersion = "19041"
 "$sdkVersion" | Out-File .windows-10-sdk-version
 
 $output = & "$PSScriptRoot\..\bin\prepare_windows_host_for_app_distribution.ps1" -SkipWindows10SDKInstallation


### PR DESCRIPTION
Closes AINFRA-1096

Windows 10 SDK 20348 doesn't appear available for download via the VS code bootstrapping tool, but 
19041 still works.

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
