### PR TITLE
Update `run_swiftlint` to allow for custom .swiftlint config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add `--config` argument to `run_swiftlint` script to allow specifying custom `.swiftlint.yml` config files [#189]
+- Add `--config` argument to `run_swiftlint` script to allow specifying custom `.swiftlint.yml` config files and allowing for multiple `--config` arguments [#189]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `--config` argument to `run_swiftlint` script to allow specifying custom `.swiftlint.yml` config files [#189]
 
 ### Bug Fixes
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -34,7 +34,6 @@ fi
 # If no config files specified, use default
 if [[ ${#CONFIG_FILES[@]} -eq 0 ]]; then
   CONFIG_FILES=(".swiftlint.yml")
-  SWIFTLINT_ARGUMENTS+=(--config ".swiftlint.yml")
 fi
 
 # Validate all config files exist

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -3,6 +3,7 @@
 echo "--- :swift: Running SwiftLint"
 
 SWIFTLINT_ARGUMENTS=(--quiet --reporter relative-path)
+CONFIG_FILE=".swiftlint.yml"
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -10,25 +11,39 @@ while [[ "$#" -gt 0 ]]; do
       SWIFTLINT_ARGUMENTS+=("$1")
       shift
       ;;
+    --config)
+      if [[ -z "$2" || "$2" =~ ^- ]]; then
+        echo "Error: --config requires a config file path"
+        echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]"
+        exit 1
+      fi
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
     *) break ;;
   esac
 done
 
 if [[ $# -gt 0 ]]; then
   echo "Error: invalid arguments."
-  echo "Usage: $0 [--strict | --lenient]"
+  echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]"
   exit 1
 fi
 
-SWIFTLINT_VERSION="$(<.swiftlint.yml awk '/^swiftlint_version: / {print $2}')"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Error: config file '$CONFIG_FILE' not found."
+  exit 1
+fi
+
+SWIFTLINT_VERSION="$(<"$CONFIG_FILE" awk '/^swiftlint_version: / {print $2}')"
 if [ -z "$SWIFTLINT_VERSION" ]; then
-  echo "Your \`.swiftlint.yml\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
+  echo "Your \`$CONFIG_FILE\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
   exit 1
 fi
 SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION" swiftlint)
 
 set +e
-SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")
+SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint --config "$CONFIG_FILE" "${SWIFTLINT_ARGUMENTS[@]}")
 SWIFTLINT_EXIT_STATUS=$?
 set -e
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -3,7 +3,7 @@
 echo "--- :swift: Running SwiftLint"
 
 SWIFTLINT_ARGUMENTS=(--quiet --reporter relative-path)
-CONFIG_FILE=".swiftlint.yml"
+CONFIG_FILES=()
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
@@ -14,10 +14,11 @@ while [[ "$#" -gt 0 ]]; do
     --config)
       if [[ -z "$2" || "$2" =~ ^- ]]; then
         echo "Error: --config requires a config file path"
-        echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]"
+        echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]..."
         exit 1
       fi
-      CONFIG_FILE="$2"
+      CONFIG_FILES+=("$2")
+      SWIFTLINT_ARGUMENTS+=(--config "$2")
       shift 2
       ;;
     *) break ;;
@@ -26,24 +27,35 @@ done
 
 if [[ $# -gt 0 ]]; then
   echo "Error: invalid arguments."
-  echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]"
+  echo "Usage: $0 [--strict | --lenient] [--config CONFIG_FILE]..."
   exit 1
 fi
 
-if [[ ! -f "$CONFIG_FILE" ]]; then
-  echo "Error: config file '$CONFIG_FILE' not found."
-  exit 1
+# If no config files specified, use default
+if [[ ${#CONFIG_FILES[@]} -eq 0 ]]; then
+  CONFIG_FILES=(".swiftlint.yml")
+  SWIFTLINT_ARGUMENTS+=(--config ".swiftlint.yml")
 fi
 
-SWIFTLINT_VERSION="$(<"$CONFIG_FILE" awk '/^swiftlint_version: / {print $2}')"
+# Validate all config files exist
+for config_file in "${CONFIG_FILES[@]}"; do
+  if [[ ! -f "$config_file" ]]; then
+    echo "Error: config file '$config_file' not found."
+    exit 1
+  fi
+done
+
+# Use the first config file to determine SwiftLint version
+FIRST_CONFIG_FILE="${CONFIG_FILES[0]}"
+SWIFTLINT_VERSION="$(<"$FIRST_CONFIG_FILE" awk '/^swiftlint_version: / {print $2}')"
 if [ -z "$SWIFTLINT_VERSION" ]; then
-  echo "Your \`$CONFIG_FILE\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
+  echo "Your \`$FIRST_CONFIG_FILE\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
   exit 1
 fi
 SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION" swiftlint)
 
 set +e
-SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint --config "$CONFIG_FILE" "${SWIFTLINT_ARGUMENTS[@]}")
+SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")
 SWIFTLINT_EXIT_STATUS=$?
 set -e
 


### PR DESCRIPTION
Related to https://github.com/Automattic/buildkite-ci/pull/707, this PR updates the `run_swiftlint` script to allow the `--config` parameter specifying a SwiftLint config file.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
