### PR TITLE
Use `cp -R` over `cp -r` — Addresses SC2336

### DIFF
--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -12,7 +12,7 @@ mkdir -p "$GRADLE_DEP_CACHE"
 
 # https://docs.gradle.org/current/userguide/dependency_resolution.html#sub:cache_copy
 # Gradle suggests removing the `*.lock` files and the `gc.properties` file before saving cache
-cp -r ~/.gradle/caches/modules-2 "$GRADLE_DEP_CACHE" \
+cp -R ~/.gradle/caches/modules-2 "$GRADLE_DEP_CACHE" \
     && find "$GRADLE_DEP_CACHE" -name "*.lock" -type f -delete \
     && find "$GRADLE_DEP_CACHE" -name "gc.properties" -type f -delete
 


### PR DESCRIPTION
A new ShellCheck version was released since the last `trunk` merge with a new check, SC2336:

- https://github.com/koalaman/shellcheck/issues/2302
- https://github.com/koalaman/shellcheck/pull/3292
- https://unix.stackexchange.com/questions/18712/difference-between-cp-r-and-cp-r-copy-command/18718#18718

The TL;DR is that `-r` is a legacy option with a slightly different behavior from `-R` regarding symlinks.

It seems safe to go with what ShellCheck suggests.


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. - N.A.
