### PR TITLE
Add `git-conceal-unlock` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `git-conceal-unlock` helper script to download & install [`git-conceal`](https://github.com/Automattic/git-conceal) if not present, then run `git-conceal unlock`. [#195]
 
 ### Bug Fixes
 

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -16,15 +16,13 @@ env_var_name=${1:-GIT_CONCEAL_SECRET_KEY}
 
 # If installed in the $PATH, execute it (replacing this current process)
 if command -v git-conceal &> /dev/null; then
-    git-conceal unlock "env:${env_var_name}"
-    exit $?
+    exec git-conceal unlock "env:${env_var_name}"
 fi
 
 INSTALL_DIR="${PWD}"
 # If already installed in INSTALL_DIR, execute it (replacing this current process)
 if [[ -x "${INSTALL_DIR}/git-conceal" ]]; then
-    "${INSTALL_DIR}/git-conceal" unlock "env:${env_var_name}"
-    exit $?
+    exec "${INSTALL_DIR}/git-conceal" unlock "env:${env_var_name}"
 fi
 
 # Otherwise, install it locally and execute it

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Description:
+#   A wrapper script to run `git-conceal unlock` on CI
+#   See https://github.com/Automattic/git-conceal
+#
+#   The wrapper automatically runs the `install.sh` script of `git-conceal`
+#   if it's not already installed locally before running `git-conceal unlock env:…`.
+#
+# By default, it uses the `GIT_CONCEAL_SECRET_KEY` environment variable as the key source.
+# You can override it by passing the environment variable name as the first argument.
+#
+
+set -euo pipefail
+
+env_var_name=${1:-GIT_CONCEAL_SECRET_KEY}
+
+# If installed in the $PATH, execute it (replacing this current process)
+if command -v git-conceal &> /dev/null; then
+    git-conceal unlock "env:${env_var_name}"
+    exit $?
+fi
+
+INSTALL_DIR="${PWD}"
+# If was already previously installed in INSTALL_DIR, execute it (replacing this current process)
+if [[ -x "${INSTALL_DIR}/git-conceal" ]]; then
+    "${INSTALL_DIR}/git-conceal" unlock "env:${env_var_name}"
+    exit $?
+fi
+
+# Otherwise, install it locally and execute it
+echo "git-conceal binary not found. Installing it..."
+mkdir -p "${INSTALL_DIR}"
+curl -fsSL https://raw.githubusercontent.com/Automattic/git-conceal/trunk/install.sh | bash -s -- --prefix "${INSTALL_DIR}"
+"${INSTALL_DIR}/git-conceal" unlock "env:${env_var_name}"

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -12,6 +12,10 @@
 
 set -euo pipefail
 
+# Note: this default env var name has been purposely chosen with a `_SECRET_KEY` suffix
+# so that Buildkite will automatically redact any accidental leak of its value in CI logs.
+# See https://buildkite.com/docs/agent/v3/cli-pipeline#redacted-vars
+# See https://github.com/buildkite/elastic-ci-stack-s3-secrets-hooks/blob/cb27042/s3secrets-helper/secrets/secrets.go#L31-L38
 env_var_name=${1:-GIT_CONCEAL_SECRET_KEY}
 
 # If installed in the $PATH, execute it (replacing this current process)

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -21,7 +21,7 @@ if command -v git-conceal &> /dev/null; then
 fi
 
 INSTALL_DIR="${PWD}"
-# If was already previously installed in INSTALL_DIR, execute it (replacing this current process)
+# If already installed in INSTALL_DIR, execute it (replacing this current process)
 if [[ -x "${INSTALL_DIR}/git-conceal" ]]; then
     "${INSTALL_DIR}/git-conceal" unlock "env:${env_var_name}"
     exit $?

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -9,7 +9,6 @@
 #
 # By default, it uses the `GIT_CONCEAL_SECRET_KEY` environment variable as the key source.
 # You can override it by passing the environment variable name as the first argument.
-#
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes [AINFRA-1606](https://linear.app/a8c/issue/AINFRA-1606/finalize-implementation-of-git-conceal)

## What?

This PR adds `bin/git-conceal-unlock` helper which takes care of downloading `git-conceal` (using the `install.sh` script from https://github.com/Automattic/git-conceal/pull/3) if it's not installed on the CI machine first, then executing `git-conceal unlock env:${1:-GIT_CONCEAL_SECRET_KEY}` to unlock the repo.

## Testing

This has been tested as part of https://github.com/woocommerce/woocommerce-android/pull/14979

## Changelog

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
