### PR TITLE
Prepare 6.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,11 @@ _None._
 
 ### Breaking Changes
 
-- Removed the `prepare_windows_host_for_app_distribution.ps1` script, given what it was installing is now already pre-provisioned in our custom Windows AMI. [#196]
-- Removed the scripts to install Python and Windows 10 SDK, given they now come pre-installed in our custom Windows AMI. [#197]
-- Removed script to refresh the environment after a Chocolatey install. This functionality is also already available in the custom Windows AMI. [#197]
+_None._
 
 ### New Features
 
-- Add `git-conceal-unlock` helper script to download & install [`git-conceal`](https://github.com/Automattic/git-conceal) if not present, then run `git-conceal unlock`. [#195]
+_None._
 
 ### Bug Fixes
 
@@ -49,6 +47,18 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 6.0.0
+
+### Breaking Changes
+
+- Removed the `prepare_windows_host_for_app_distribution.ps1` script, given what it was installing is now already pre-provisioned in our custom Windows AMI. [#196]
+- Removed the scripts to install Python and Windows 10 SDK, given they now come pre-installed in our custom Windows AMI. [#197]
+- Removed script to refresh the environment after a Chocolatey install. This functionality is also already available in the custom Windows AMI. [#197]
+
+### New Features
+
+- Add `git-conceal-unlock` helper script to download & install [`git-conceal`](https://github.com/Automattic/git-conceal) if not present, then run `git-conceal unlock`. [#195]
 
 ## 5.7.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,12 @@
 # Migration Instructions for Major Releases
 
+## From 5.0.0 to 6.0.0
+
+Breaking changes in this release only affect pipelines building on Windows agents:
+* The `prepare_windows_host_for_app_distribution.ps1` script has been removed, as its functionality is now pre-provisioned in our custom Windows AMI. Remove any calls to this script from your pipeline steps.
+* Scripts to install Python and Windows 10 SDK have been removed, as they are now pre-installed in our custom Windows AMI. Remove any calls to these scripts from your pipeline steps.
+* The script to refresh the environment after a Chocolatey install has been removed, as this functionality is now available in the custom Windows AMI. Remove any calls to this script from your pipeline steps.
+
 ## From 4.0.0 to 5.0.0
 
 * Use `prepare_windows_host_for_app_distribution.ps1` instead of `prepare_windows_host_for_node.ps1`.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#5.7.0:
+      - automattic/a8c-ci-toolkit#6.0.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `5.7.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.0.0`.
 
 ## Configuration
 


### PR DESCRIPTION
This PR prepares the 6.0.0 release by:

- Updating version references in README.md from 5.7.0 to 6.0.0
- Moving Unreleased changes to 6.0.0 section in CHANGELOG.md
- Adding a new Unreleased section for future changes
- Adding migration guide from 5.0.0 to 6.0.0 in MIGRATION.md

This is a major version bump due to breaking changes affecting Windows agents (removed scripts that are now pre-provisioned in the custom Windows AMI).

> [!NOTE]
> 🎗️  Once this PR lands in `trunk`, don't forget to create a GitHub Release named `6.0.0` with the content of the `CHANGELOG.md` for that version. This will create the namesake Git tag, thus finalizing and officialising the release.