### PR TITLE
Update SwiftLint invocation to work with its 0.60.0 Docker img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- `run_swiftlint` now supports SwiftLint 0.60.0 and above. [#199]
 
 ### Internal Changes
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -64,12 +64,16 @@ ERRORS=$(echo -e "$SWIFTLINT_OUTPUT" | awk -F': ' '/: error:/ {printf "- `%s`: %
 
 if [ -n "$WARNINGS" ]; then
   echo "$WARNINGS"
-  printf "**SwiftLint Warnings**\n%b" "$WARNINGS" | buildkite-agent annotate --style 'warning'
+  if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
+    printf "**SwiftLint Warnings**\n%b" "$WARNINGS" | buildkite-agent annotate --style 'warning'
+  fi
 fi
 
 if [ -n "$ERRORS" ]; then
   echo "$ERRORS"
-  printf "**SwiftLint Errors**\n%b" "$ERRORS" | buildkite-agent annotate --style 'error'
+  if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
+    printf "**SwiftLint Errors**\n%b" "$ERRORS" | buildkite-agent annotate --style 'error'
+  fi
 fi
 
 printf "SwiftLint completed with %s.\n" $SWIFTLINT_EXIT_STATUS

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -71,4 +71,7 @@ if [ -n "$ERRORS" ]; then
   printf "**SwiftLint Errors**\n%b" "$ERRORS" | buildkite-agent annotate --style 'error'
 fi
 
+printf "SwiftLint completed with %s.\n" $SWIFTLINT_EXIT_STATUS
+printf "Will exit script with the same exit code.\n"
+
 exit $SWIFTLINT_EXIT_STATUS

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -76,7 +76,6 @@ if [ -n "$ERRORS" ]; then
   fi
 fi
 
-printf "SwiftLint completed with %s.\n" $SWIFTLINT_EXIT_STATUS
-printf "Will exit script with the same exit code.\n"
+printf "SwiftLint completed with exit code %d\n" "$SWIFTLINT_EXIT_STATUS"
 
 exit $SWIFTLINT_EXIT_STATUS

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -54,7 +54,8 @@ fi
 SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace --entrypoint swiftlint ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION")
 
 set +e
-SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")
+# The set -x in the subshell will print the full cmd making the logs clearer
+SWIFTLINT_OUTPUT=$(set -x; "${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")
 SWIFTLINT_EXIT_STATUS=$?
 set -e
 

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -51,7 +51,7 @@ if [ -z "$SWIFTLINT_VERSION" ]; then
   echo "Your \`$FIRST_CONFIG_FILE\` file must contain a key for \`swiftlint_version:\` so that we know which version of SwiftLint to use to lint your codebase."
   exit 1
 fi
-SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION" swiftlint)
+SWIFTLINT_DOCKER_CMD=(docker run --rm -v "$PWD":/workspace -w /workspace --entrypoint swiftlint ghcr.io/realm/swiftlint:"$SWIFTLINT_VERSION")
 
 set +e
 SWIFTLINT_OUTPUT=$("${SWIFTLINT_DOCKER_CMD[@]}" lint "${SWIFTLINT_ARGUMENTS[@]}")


### PR DESCRIPTION
See:

- paaHJt-9lK-p2
- https://linear.app/a8c/issue/AINFRA-1694/investigate-error-in-calling-run-swiftlint-command-between-swiftlint
- https://github.com/Automattic/Automattic-Tracks-iOS/pull/311


See the changes between 0.59.2 and 0.60.0, in particular:

https://github.com/realm/SwiftLint/compare/0.59.1...0.60.0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L64-R60

```diff
- CMD ["swiftlint"]
+ ENTRYPOINT [ "/usr/bin/swiftlint" ]
+ CMD ["."]
```

The `ENTRYPOINT` addition and `CMD` change resulted in the invocation we
use breaking, see CI failure in https://href.li/?https://buildkite.com/automattic/tracks-ios/builds/575/steps/canvas?sid=019b9163-3de9-4451-b5e6-4b6f50935e4e

```
Error: No lintable files found at paths: 'swiftlint, lint'
```

By overriding the entrypoint via `--entrypoint swiftlint` we can maintain compatibility with versions before and after 0.60.0.

You can reproduce the issue seen in CI by:

- Cloning both this repo and [Tracks Apple](https://github.com/Automattic/Automattic-Tracks-iOS) locally.
- Checkout this repo's `trunk`
- Go to Tracks
- In `.swiftlint.yml` replace `whitelist_rules` with `only_rules`. That configuration key has become invalid some time ago. _This is not required for the test, but will keep the lint errors to a minimum._
- Run `echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin` to authenticate with GHCR
- `docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:0.59.1 swiftlint lint` to see lint issues
- `docker run --rm -v "$PWD":/workspace -w /workspace ghcr.io/realm/swiftlint:0.60.0 swiftlint lint` to see the error reported above

You can verify the fix here by:

- Checking out this branch
- Going back to Tracks and adding `swiftlint_version: 0.59.1` at the top of its `.swiftlint.yml`
- Running `<path/to/ci-toolkit/>bin/run_swiftlint` and verifying is succeeds
- Updating Tracks' `swiftlint_version` to `0.60.0`, or any value above it up to its latest, 0.63.0
- Back in this repo, running `<path/to/ci-toolkit/>bin/run_swiftlint` once more, and verifying is succeeds

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.