### PR TITLE
Prepare 6.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- `run_swiftlint` now supports SwiftLint 0.60.0 and above. [#199]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 6.0.1
+
+### Bug Fixes
+
+- `run_swiftlint` now supports SwiftLint 0.60.0 and above. [#199]
 
 ## 6.0.0
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#6.0.0:
+      - automattic/a8c-ci-toolkit#6.0.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.0.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.0.1`.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- Update version references in README.md from 6.0.0 to 6.0.1
- Add CHANGELOG.md entry for 6.0.1 release with the bug fix for SwiftLint 0.60.0 support

## Changes in this release

### Bug Fixes

- `run_swiftlint` now supports SwiftLint 0.60.0 and above. [#199]

## Next steps

After merging this PR:
1. Create a new GitHub Release named `6.0.1`
2. Paste the CHANGELOG.md section for 6.0.1 as the release description

🤖 Generated with [Claude Code](https://claude.com/claude-code)