### PR TITLE
Add proper exit code checks to Windows code signing script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Enhanced error handling in `setup_windows_code_signing.ps1` [#201]
 
 ## 6.0.1
 

--- a/bin/setup_windows_code_signing.ps1
+++ b/bin/setup_windows_code_signing.ps1
@@ -13,17 +13,25 @@ Write-Output "--- :lock_with_ink_pen: Download Code Signing Certificate"
 
 $certificateBinPath = "certificate.bin"
 
-$EncodedText = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate `
-  | jq -r '.SecretString' `
-  | Out-File $certificateBinPath
+$secretJson = aws secretsmanager get-secret-value --secret-id windows-code-signing-certificate 2>&1
+If ($LastExitCode -ne 0) {
+  Write-Output "[!] Failed to retrieve secret from AWS SecretsManager."
+  Write-Output $secretJson
+  Exit $LastExitCode
+}
+
+$secretJson | jq -r '.SecretString' | Out-File $certificateBinPath
+If ($LastExitCode -ne 0) {
+  Write-Output "[!] Failed to parse secret JSON with jq."
+  Exit $LastExitCode
+}
 
 $certificatePfxPath = "certificate.pfx"
 
 certutil -decode $certificateBinPath $certificatePfxPath
-
 If ($LastExitCode -ne 0) {
-  Write-Output "[!] Failed to download code signing certificate."
+  Write-Output "[!] Failed to decode certificate."
   Exit $LastExitCode
-} else {
-  Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"
 }
+
+Write-Output "Code signing certificate downloaded at: $((Get-Item $certificatePfxPath).FullName)"


### PR DESCRIPTION
## Summary
- Audits and fixes exit code reporting in `setup_windows_code_signing.ps1`
- Adds `$LastExitCode` checks after AWS CLI and jq commands
- Each failure path now exits with a specific error message

Previously, failures from `aws secretsmanager` or `jq` would be silently ignored, and only `certutil` failures were caught.

## Test plan
- [ ] Run on a Windows agent to verify the script still works
- [ ] Optionally test failure paths by using invalid secret IDs

Closes AINFRA-1466

🤖 Generated with [Claude Code](https://claude.com/claude-code)