### PR TITLE
Add macOS sign_and_notarize command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add `sign_and_notarize`: code-sign (Developer ID, hardened runtime) and notarize macOS artifacts — bare binaries, `.app`, `.dmg`, or `.pkg`.
+- Add `sign_and_notarize`: code-sign (Developer ID, hardened runtime) and notarize macOS artifacts — bare binaries, `.app`, or `.dmg`.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `sign_and_notarize`: code-sign (Developer ID, hardened runtime) and notarize macOS artifacts — bare binaries, `.app`, `.dmg`, or `.pkg`.
 
 ### Bug Fixes
 

--- a/bin/sign_and_notarize
+++ b/bin/sign_and_notarize
@@ -110,6 +110,9 @@ sign() {
 	echo "==> codesigning $target"
 	codesign "${opts[@]}" "$target"
 	codesign --verify --strict --verbose=2 "$target"
+	# Surface which cert and team identifier actually applied — invaluable when a
+	# Gatekeeper rejection lands in production and you need to confirm the signer.
+	codesign --display --verbose=2 "$target" 2>&1 | grep -E "Authority|TeamIdentifier|Signature|flags|Hash" || true
 }
 
 notarize() {

--- a/bin/sign_and_notarize
+++ b/bin/sign_and_notarize
@@ -1,0 +1,177 @@
+#!/bin/bash -eu
+
+# Usage
+# sign_and_notarize [--team-id TEAM_ID] [--entitlements FILE] <artifact> [<artifact>...]
+#
+# Code-signs (Developer ID, hardened runtime) and notarizes one or more macOS artifacts: bare
+# executables, `.app` bundles, `.dmg`, or `.pkg`. Build-agnostic — point it at whatever your build
+# produced.
+#
+# The Developer ID Application certificate must already be in the keychain (e.g. fetched via
+# `fastlane match` / a `set_up_signing` lane before calling this). The identity is resolved from the
+# keychain by team id; set `IDENTITY` to force a specific one.
+#
+# Required environment (App Store Connect API key, used by notarytool):
+#   APP_STORE_CONNECT_API_KEY_KEY_ID
+#   APP_STORE_CONNECT_API_KEY_ISSUER_ID
+#   APP_STORE_CONNECT_API_KEY_KEY      (the .p8 PEM; `\n` escapes are decoded)
+#
+# Options:
+#   --team-id TEAM_ID       Apple team id used to resolve the signing identity (default: PZYM8XX95Q).
+#   --entitlements FILE     Entitlements plist to sign with; omit for a plain CLI under hardened runtime.
+
+TEAM_ID_DEFAULT="PZYM8XX95Q"
+
+team_id="${TEAM_ID:-$TEAM_ID_DEFAULT}"
+entitlements=""
+artifacts=()
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+		--team-id)
+			team_id="${2-}"
+			[ -n "$team_id" ] || { echo "missing value for --team-id" >&2; exit 1; }
+			shift 2
+			;;
+		--entitlements)
+			entitlements="${2-}"
+			[ -n "$entitlements" ] || { echo "missing value for --entitlements" >&2; exit 1; }
+			shift 2
+			;;
+		-h|--help)
+			echo "usage: sign_and_notarize [--team-id TEAM_ID] [--entitlements FILE] <artifact> [<artifact>...]"
+			exit 0
+			;;
+		-*)
+			echo "unknown option: $1" >&2
+			exit 1
+			;;
+		*)
+			artifacts+=("$1")
+			shift
+			;;
+	esac
+done
+
+if [ "${#artifacts[@]}" -eq 0 ]; then
+	echo "you must pass at least one artifact to sign and notarize" >&2
+	exit 1
+fi
+
+key_id="${APP_STORE_CONNECT_API_KEY_KEY_ID-}"
+issuer_id="${APP_STORE_CONNECT_API_KEY_ISSUER_ID-}"
+key_pem="${APP_STORE_CONNECT_API_KEY_KEY-}"
+
+if [ -z "$key_id" ] || [ -z "$issuer_id" ] || [ -z "$key_pem" ]; then
+	echo "missing API key env: set APP_STORE_CONNECT_API_KEY_{KEY_ID,ISSUER_ID,KEY}" >&2
+	exit 2
+fi
+
+if [ -n "$entitlements" ] && [ ! -f "$entitlements" ]; then
+	echo "entitlements file not found: $entitlements" >&2
+	exit 3
+fi
+
+# Resolve the Developer ID Application identity from the keychain by team id, so this works for any
+# such cert without hardcoding the org name. `IDENTITY` bypasses the lookup.
+identity="${IDENTITY:-}"
+if [ -z "$identity" ]; then
+	identity=$(security find-identity -v -p codesigning | awk -v team="($team_id)" '
+		/Developer ID Application:/ && index($0, team) {
+			sub(/^[^"]*"/, "")
+			sub(/"[^"]*$/, "")
+			print
+			exit
+		}
+	')
+fi
+
+if [ -z "$identity" ]; then
+	echo "no Developer ID Application identity for team $team_id in keychain (set IDENTITY= to override)" >&2
+	exit 4
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+
+# notarytool wants the key as a .p8 file. The env var stores the PEM with `\n` as a literal
+# backslash-n; %b decodes the escapes, and the trailing newline avoids notarytool rejecting the PEM
+# as `invalidPEMDocument`.
+p8="$work/AuthKey_$key_id.p8"
+printf '%b\n' "$key_pem" > "$p8"
+chmod 600 "$p8"
+
+sign() {
+	local target="$1"
+	local opts=(--force --options runtime --timestamp --sign "$identity")
+	if [ -n "$entitlements" ]; then
+		opts+=(--entitlements "$entitlements")
+	fi
+	echo "==> codesigning $target"
+	codesign "${opts[@]}" "$target"
+	codesign --verify --strict --verbose=2 "$target"
+}
+
+notarize() {
+	local target="$1"
+	local payload="$target"
+
+	# .dmg and .pkg submit directly; everything else (bare binary, .app bundle) must be zipped first.
+	case "$target" in
+		*.dmg|*.pkg) ;;
+		*)
+			payload="$work/$(basename "$target").zip"
+			if [ -d "$target" ]; then
+				ditto -c -k --keepParent "$target" "$payload"
+			else
+				ditto -c -k "$target" "$payload"
+			fi
+			;;
+	esac
+
+	echo "==> notarizing $target (waiting on Apple, can take a few minutes)"
+	local out="$work/notary.json"
+	xcrun notarytool submit "$payload" \
+		--key "$p8" \
+		--key-id "$key_id" \
+		--issuer "$issuer_id" \
+		--wait \
+		--output-format json > "$out"
+
+	local status submission_id
+	status=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "$out")
+	submission_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["id"])' "$out")
+
+	if [ "$status" != "Accepted" ]; then
+		echo "==> notarization $status — fetching log" >&2
+		xcrun notarytool log "$submission_id" --key "$p8" --key-id "$key_id" --issuer "$issuer_id" >&2
+		exit 5
+	fi
+
+	# Stapling attaches the ticket for offline Gatekeeper checks. Only bundles and installers can hold
+	# a ticket; a bare binary relies on online notarization, so there's nothing to staple.
+	case "$target" in
+		*.dmg|*.pkg)
+			xcrun stapler staple "$target"
+			;;
+		*)
+			if [ -d "$target" ]; then
+				xcrun stapler staple "$target"
+			else
+				echo "==> bare binary: notarized, nothing to staple"
+			fi
+			;;
+	esac
+
+	echo "==> notarized $target (id=$submission_id)"
+}
+
+for artifact in "${artifacts[@]}"; do
+	if [ ! -e "$artifact" ]; then
+		echo "no such artifact: $artifact" >&2
+		exit 6
+	fi
+	echo "--- :apple: $artifact"
+	sign "$artifact"
+	notarize "$artifact"
+done

--- a/bin/sign_and_notarize
+++ b/bin/sign_and_notarize
@@ -4,7 +4,7 @@
 # sign_and_notarize [--team-id TEAM_ID] [--entitlements FILE] <artifact> [<artifact>...]
 #
 # Code-signs (Developer ID, hardened runtime) and notarizes one or more macOS artifacts: bare
-# executables, `.app` bundles, `.dmg`, or `.pkg`. Build-agnostic — point it at whatever your build
+# executables, `.app` bundles, or `.dmg`. Build-agnostic — point it at whatever your build
 # produced.
 #
 # The Developer ID Application certificate must already be in the keychain (e.g. fetched via
@@ -119,9 +119,9 @@ notarize() {
 	local target="$1"
 	local payload="$target"
 
-	# .dmg and .pkg submit directly; everything else (bare binary, .app bundle) must be zipped first.
+	# .dmg submits directly; everything else (bare binary, .app bundle) must be zipped first.
 	case "$target" in
-		*.dmg|*.pkg) ;;
+		*.dmg) ;;
 		*)
 			payload="$work/$(basename "$target").zip"
 			if [ -d "$target" ]; then
@@ -151,10 +151,10 @@ notarize() {
 		exit 5
 	fi
 
-	# Stapling attaches the ticket for offline Gatekeeper checks. Only bundles and installers can hold
+	# Stapling attaches the ticket for offline Gatekeeper checks. Only bundles and disk images can hold
 	# a ticket; a bare binary relies on online notarization, so there's nothing to staple.
 	case "$target" in
-		*.dmg|*.pkg)
+		*.dmg)
 			xcrun stapler staple "$target"
 			;;
 		*)

--- a/tests/test_sign_and_notarize.bats
+++ b/tests/test_sign_and_notarize.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# These cases cover the argument and environment contract only — the paths that run before any
+# macOS-specific tool (codesign, security, xcrun) is invoked — so they are portable to the Linux
+# plugin-tester. The actual signing/notarization is exercised on real macOS CI via a consuming repo.
+
+SCRIPT="$BATS_TEST_DIRNAME/../bin/sign_and_notarize"
+
+# Dummy API key env so the cases that should fail *later* (e.g. on a bad entitlements path) get past
+# the env check without reaching any macOS tool.
+with_dummy_api_key() {
+	export APP_STORE_CONNECT_API_KEY_KEY_ID="dummy"
+	export APP_STORE_CONNECT_API_KEY_ISSUER_ID="dummy"
+	export APP_STORE_CONNECT_API_KEY_KEY="dummy"
+}
+
+@test "--help prints usage and exits 0" {
+	run "$SCRIPT" --help
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "usage: sign_and_notarize" ]]
+}
+
+@test "no artifact arguments fails" {
+	with_dummy_api_key
+	run "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "at least one artifact" ]]
+}
+
+@test "unknown option fails" {
+	with_dummy_api_key
+	run "$SCRIPT" --nope artifact
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "unknown option" ]]
+}
+
+@test "--team-id without a value fails" {
+	with_dummy_api_key
+	run "$SCRIPT" --team-id
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "missing value for --team-id" ]]
+}
+
+@test "missing API key environment fails" {
+	unset APP_STORE_CONNECT_API_KEY_KEY_ID
+	unset APP_STORE_CONNECT_API_KEY_ISSUER_ID
+	unset APP_STORE_CONNECT_API_KEY_KEY
+	run "$SCRIPT" some-artifact
+	[ "$status" -eq 2 ]
+	[[ "$output" =~ "APP_STORE_CONNECT_API_KEY" ]]
+}
+
+@test "missing entitlements file fails before signing" {
+	with_dummy_api_key
+	run "$SCRIPT" --entitlements /no/such/file.entitlements some-artifact
+	[ "$status" -eq 3 ]
+	[[ "$output" =~ "entitlements file not found" ]]
+}


### PR DESCRIPTION
Adds a `sign_and_notarize` command. The toolkit has a Windows code-signing command but no macOS counterpart, so consuming pipelines ([platform-imessage](https://github.com/beeper/platform-imessage) today; [bbctl](https://github.com/beeper/bridge-manager) and [Cortext](https://github.com/Automattic/cortext) next) each hand-roll the same `codesign` + `notarytool` script. This centralizes it.

The command is build-agnostic — point it at whatever the build produced (bare binary, `.app`, or `.dmg`).

### Gotcha

Bare binaries are intentionally **not** stapled — only bundles/installers can carry a stapled ticket; a bare binary relies on online notarization.

### How to test

- `make test` runs the bats arg/env contract cases.
- Real end-to-end signing runs on macOS CI via the [platform-imessage refactor](https://github.com/beeper/platform-imessage/pull/100), which repoints its toolkit plugin pin at this branch.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.