### PR TITLE
Restore cache from Synology NAS before S3 on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on macOS hosts, avoiding billed S3 egress, and annotates each restore's source (NAS / S3 / miss). [#216]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on macOS hosts, avoiding billed S3 egress, and annotates the job whenever a restore still falls back to S3. [#216]
+- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on the macOS fleet, avoiding billed S3 egress, and annotates the job whenever a restore falls back to S3. [#216]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on macOS hosts, avoiding billed S3 egress, and annotates each restore's source (NAS / S3 / miss). [#216]
+- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on macOS hosts, avoiding billed S3 egress, and annotates the job whenever a restore still falls back to S3. [#216]
 
 ### Bug Fixes
 

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -20,22 +20,38 @@ fi
 
 echo "Using $S3_BUCKET_NAME as cache bucket"
 
-if aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1; then
-	SECONDS=0
-	echo "Restoring cache entry $CACHE_KEY"
+# On the macOS (CyberLynk) fleet, a Synology NAS mirrors the cache bucket on the
+# LAN and serves it over HTTP, so we fetch from it first to avoid billed S3
+# egress and fall back to S3. Mirrors hostmgr: connect by IP, set the Host header
+# (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
+NAS_CACHE_HOST="cache.ci.internal"
+NAS_CACHE_ADDRESS="192.168.0.250"
 
-	echo "	Downloading"
+restore_from_nas() {
+	[[ "$(uname)" == "Darwin" ]] || return 1
+	local url="http://$NAS_CACHE_ADDRESS/cache/$CACHE_KEY"
+	curl -fsS --head --max-time 5 -H "Host: $NAS_CACHE_HOST" "$url" > /dev/null 2>&1 || return 1
+	echo "	Fetching from NAS (Synology)"
+	curl -fsS -H "Host: $NAS_CACHE_HOST" "$url" -o "$CACHE_KEY"
+}
+
+restore_from_s3() {
+	aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1 || return 1
+	echo "	Fetching from AWS S3"
 	# If the bucket has transfer acceleration enabled, use it!
 	ACCELERATION_STATUS=$(aws s3api get-bucket-accelerate-configuration --bucket "$S3_BUCKET_NAME" | jq '.Status' -r || true)
-
 	if [ "$ACCELERATION_STATUS" = "Enabled" ]; then
-		echo "Downloading with transfer acceleration"
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet --endpoint-url https://s3-accelerate.amazonaws.com
 	else
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 	fi
+}
 
+SECONDS=0
+if restore_from_nas || restore_from_s3; then
+	echo "Restoring cache entry $CACHE_KEY"
 	CACHE_SIZE=$(wc -c < "$CACHE_KEY")
+
 	echo "	Decompressing"
 	tar -xf "$CACHE_KEY"
 

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -43,6 +43,7 @@ restore_from_s3() {
 	# If the bucket has transfer acceleration enabled, use it!
 	ACCELERATION_STATUS=$(aws s3api get-bucket-accelerate-configuration --bucket "$S3_BUCKET_NAME" | jq '.Status' -r || true)
 	if [ "$ACCELERATION_STATUS" = "Enabled" ]; then
+		echo "Downloading with transfer acceleration"
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet --endpoint-url https://s3-accelerate.amazonaws.com
 	else
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -53,7 +53,7 @@ restore_from_s3() {
 annotate() {
 	[[ "$(uname)" == "Darwin" ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
-	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --append || echo "⚠️ cache-restore annotation failed"
+	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --style info --append || echo "⚠️ cache-restore annotation failed"
 }
 
 SECONDS=0

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -20,17 +20,17 @@ fi
 
 echo "Using $S3_BUCKET_NAME as cache bucket"
 
-# On the macOS (CyberLynk) fleet, a Synology NAS mirrors the cache bucket on the
-# LAN and serves it over HTTP, so we fetch from it first to avoid billed S3
-# egress and fall back to S3. Mirrors hostmgr: connect by IP, set the Host header
-# (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
-NAS_CACHE_HOST="cache.ci.internal"
-NAS_CACHE_ADDRESS="192.168.0.250"
+# A Synology NAS on the macOS (CyberLynk) fleet's LAN mirrors the cache bucket
+# and serves it over HTTP, so we fetch from it first to avoid billed S3 egress
+# and fall back to S3. BUILDKITE_NAS_CACHE_HOST / _ADDRESS are exported only on
+# those agents (via buildkite-ci's macOS environment hooks); the BUILDKITE_ prefix
+# is what lets hostmgr forward them into the build VM, so their presence enables
+# the NAS path. Mirrors hostmgr: connect by IP, set the Host header (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
+NAS_CACHE_HOST=${BUILDKITE_NAS_CACHE_HOST:-}
+NAS_CACHE_ADDRESS=${BUILDKITE_NAS_CACHE_ADDRESS:-}
 
-# The NAS is only reachable from the macOS (CyberLynk) fleet, so only those
-# hosts try it; everything else goes straight to S3.
 SHOULD_TRY_NAS=false
-[[ "$(uname)" == "Darwin" ]] && SHOULD_TRY_NAS=true
+[[ -n "$NAS_CACHE_HOST" && -n "$NAS_CACHE_ADDRESS" ]] && SHOULD_TRY_NAS=true
 
 restore_from_nas() {
 	[[ "$SHOULD_TRY_NAS" == true ]] || return 1

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -53,7 +53,7 @@ restore_from_s3() {
 annotate() {
 	[[ "$(uname)" == "Darwin" ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
-	buildkite-agent annotate "- $1" --context cache-restore --append > /dev/null 2>&1 || true
+	buildkite-agent annotate "- $1" --context cache-restore --scope job --append > /dev/null 2>&1 || true
 }
 
 SECONDS=0

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -53,7 +53,7 @@ restore_from_s3() {
 annotate() {
 	[[ "$(uname)" == "Darwin" ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
-	buildkite-agent annotate "- $1" --context cache-restore --scope job --append > /dev/null 2>&1 || true
+	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --append || echo "⚠️ cache-restore annotation failed"
 }
 
 SECONDS=0

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -32,14 +32,12 @@ restore_from_nas() {
 	local url="http://$NAS_CACHE_ADDRESS/cache/$CACHE_KEY"
 	curl -fsS --head --max-time 5 -H "Host: $NAS_CACHE_HOST" "$url" > /dev/null 2>&1 || return 1
 	echo "	Fetching from NAS (Synology)"
-	SOURCE="✅ NAS"
 	curl -fsS -H "Host: $NAS_CACHE_HOST" "$url" -o "$CACHE_KEY"
 }
 
 restore_from_s3() {
 	aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1 || return 1
 	echo "	Fetching from AWS S3"
-	SOURCE="⚠️ S3"
 	# If the bucket has transfer acceleration enabled, use it!
 	ACCELERATION_STATUS=$(aws s3api get-bucket-accelerate-configuration --bucket "$S3_BUCKET_NAME" | jq '.Status' -r || true)
 	if [ "$ACCELERATION_STATUS" = "Enabled" ]; then
@@ -47,13 +45,14 @@ restore_from_s3() {
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet --endpoint-url https://s3-accelerate.amazonaws.com
 	else
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
-	fi
+	fi || return 1
+	annotate "S3 fallback \`$CACHE_KEY\`"
 }
 
 annotate() {
 	[[ "$(uname)" == "Darwin" ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
-	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --style info --append || echo "⚠️ cache-restore annotation failed"
+	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --style warning --append || echo "⚠️ cache-restore annotation failed"
 }
 
 SECONDS=0
@@ -67,13 +66,10 @@ if restore_from_nas || restore_from_s3; then
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
 
-	annotate "$SOURCE \`$CACHE_KEY\` ($(bytes_to_mb "$CACHE_SIZE") MB)"
-
 	duration=$SECONDS
 	echo "Cache entry successfully restored"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
 	echo "	Cache Size: $(bytes_to_mb "$CACHE_SIZE") MB"
 else
 	echo "No cache entry found for '$CACHE_KEY'"
-	annotate "ℹ️ none \`$CACHE_KEY\` – resolved fresh"
 fi

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -27,8 +27,13 @@ echo "Using $S3_BUCKET_NAME as cache bucket"
 NAS_CACHE_HOST="cache.ci.internal"
 NAS_CACHE_ADDRESS="192.168.0.250"
 
+# The NAS is only reachable from the macOS (CyberLynk) fleet, so only those
+# hosts try it; everything else goes straight to S3.
+SHOULD_TRY_NAS=false
+[[ "$(uname)" == "Darwin" ]] && SHOULD_TRY_NAS=true
+
 restore_from_nas() {
-	[[ "$(uname)" == "Darwin" ]] || return 1
+	[[ "$SHOULD_TRY_NAS" == true ]] || return 1
 	local url="http://$NAS_CACHE_ADDRESS/cache/$CACHE_KEY"
 	curl -fsS --head --max-time 5 -H "Host: $NAS_CACHE_HOST" "$url" > /dev/null 2>&1 || return 1
 	echo "	Fetching from NAS (Synology)"
@@ -50,7 +55,7 @@ restore_from_s3() {
 }
 
 annotate() {
-	[[ "$(uname)" == "Darwin" ]] || return 0
+	[[ "$SHOULD_TRY_NAS" == true ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
 	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --style warning --append || echo "⚠️ cache-restore annotation failed"
 }

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -20,9 +20,14 @@ fi
 
 echo "Using $S3_BUCKET_NAME as cache bucket"
 
-# A Synology NAS on the macOS (CyberLynk) fleet's LAN mirrors the cache bucket
-# and serves it over HTTP, so we fetch from it first to avoid billed S3 egress
-# and fall back to S3. Mirrors hostmgr: connect by IP, set the Host header (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
+# Our Synology NAS maintains a mirror of the S3 cache bucket (via Synology CloudSync) and serves it over HTTP.
+# See https://github.com/Automattic/buildkite-ci/blob/trunk/docs/synology/synology-nas.md
+# So if we are on the same LAN as this NAS (i.e. macOS fleet in MacMiniVault), we fetch from it first
+# to avoid billed S3 egress, and only fall back to S3 on cache miss on the NAS.
+# Mirrors hostmgr behavior (connect by IP, set the Host header, see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
+
+# Those `BUILDKITE_NAS_CACHE_*` vars are defined in the `environment` Buildkite hook of our CI machines living in MacMiniVault in the same LAN as the NAS
+# See https://github.com/Automattic/buildkite-ci/pull/902
 NAS_CACHE_HOST=${BUILDKITE_NAS_CACHE_HOST:-}
 NAS_CACHE_ADDRESS=${BUILDKITE_NAS_CACHE_ADDRESS:-}
 
@@ -48,11 +53,13 @@ restore_from_s3() {
 	else
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 	fi || return 1
-	annotate "S3 fallback \`$CACHE_KEY\`"
+	# Only annotate about S3 fallback if we had to try NAS first and we tried S3 because NAS failed
+	if [[ "$SHOULD_TRY_NAS" == true ]]; then
+		annotate "Cache miss on NAS but hit on S3 fallback: \`$CACHE_KEY\`"
+	fi
 }
 
 annotate() {
-	[[ "$SHOULD_TRY_NAS" == true ]] || return 0
 	command -v buildkite-agent > /dev/null 2>&1 || return 0
 	printf -- "- %s\n" "$1" | buildkite-agent annotate --context cache-restore --scope job --style warning --append || echo "⚠️ cache-restore annotation failed"
 }

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -32,12 +32,14 @@ restore_from_nas() {
 	local url="http://$NAS_CACHE_ADDRESS/cache/$CACHE_KEY"
 	curl -fsS --head --max-time 5 -H "Host: $NAS_CACHE_HOST" "$url" > /dev/null 2>&1 || return 1
 	echo "	Fetching from NAS (Synology)"
+	SOURCE="✅ NAS"
 	curl -fsS -H "Host: $NAS_CACHE_HOST" "$url" -o "$CACHE_KEY"
 }
 
 restore_from_s3() {
 	aws s3api head-object --bucket "$S3_BUCKET_NAME" --key "$CACHE_KEY" > /dev/null 2>&1 || return 1
 	echo "	Fetching from AWS S3"
+	SOURCE="⚠️ S3"
 	# If the bucket has transfer acceleration enabled, use it!
 	ACCELERATION_STATUS=$(aws s3api get-bucket-accelerate-configuration --bucket "$S3_BUCKET_NAME" | jq '.Status' -r || true)
 	if [ "$ACCELERATION_STATUS" = "Enabled" ]; then
@@ -45,6 +47,12 @@ restore_from_s3() {
 	else
 		aws s3 cp "s3://$S3_BUCKET_NAME/$CACHE_KEY" "$CACHE_KEY" --quiet
 	fi
+}
+
+annotate() {
+	[[ "$(uname)" == "Darwin" ]] || return 0
+	command -v buildkite-agent > /dev/null 2>&1 || return 0
+	buildkite-agent annotate "- $1" --context cache-restore --append > /dev/null 2>&1 || true
 }
 
 SECONDS=0
@@ -58,10 +66,13 @@ if restore_from_nas || restore_from_s3; then
 	echo "	Cleaning Up"
 	rm "$CACHE_KEY"
 
+	annotate "$SOURCE \`$CACHE_KEY\` ($(bytes_to_mb "$CACHE_SIZE") MB)"
+
 	duration=$SECONDS
 	echo "Cache entry successfully restored"
 	echo "	Duration: $((duration / 60)) minutes and $((duration % 60)) seconds"
 	echo "	Cache Size: $(bytes_to_mb "$CACHE_SIZE") MB"
 else
 	echo "No cache entry found for '$CACHE_KEY'"
+	annotate "ℹ️ none \`$CACHE_KEY\` – resolved fresh"
 fi

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -22,10 +22,7 @@ echo "Using $S3_BUCKET_NAME as cache bucket"
 
 # A Synology NAS on the macOS (CyberLynk) fleet's LAN mirrors the cache bucket
 # and serves it over HTTP, so we fetch from it first to avoid billed S3 egress
-# and fall back to S3. BUILDKITE_NAS_CACHE_HOST / _ADDRESS are exported only on
-# those agents (via buildkite-ci's macOS environment hooks); the BUILDKITE_ prefix
-# is what lets hostmgr forward them into the build VM, so their presence enables
-# the NAS path. Mirrors hostmgr: connect by IP, set the Host header (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
+# and fall back to S3. Mirrors hostmgr: connect by IP, set the Host header (see https://github.com/Automattic/hostmgr/blob/fa4ed2b10e3163aec6bcffe4d6b94fc94f3466ec/Sources/libhostmgr/Servers/CacheServer.swift#L46-L72).
 NAS_CACHE_HOST=${BUILDKITE_NAS_CACHE_HOST:-}
 NAS_CACHE_ADDRESS=${BUILDKITE_NAS_CACHE_ADDRESS:-}
 


### PR DESCRIPTION
### Description

On the CyberLynk Mac fleet we serve the cache (SPM, gems, etc.) to builders over **billed S3 egress**, even though a Synology NAS on the same LAN already mirrors the `a8c-ci-cache` bucket via CloudSync.

### Change

`restore_cache now` tries the NAS first on macOS hosts (HTTP `HEAD` probe with a short timeout, then `GET`), and falls back to S3 on any miss or unreachable NAS. The chosen source is logged. Connecting by IP with a Host header mirrors `hostmgr`'s `CacheServer`.

### Context and research

paaHJt-ael-p2

### Demo

#### Gems
<img width="655" height="342" alt="image" src="https://github.com/user-attachments/assets/6ee6ee81-7fd2-4ea4-a38d-47b008644b66" />

https://buildkite.com/automattic/day-one-apple/builds/7132/list?tab=output&jid=019f6a2e-b2cf-44b0-845c-662f779d7436#L354

#### SPM
<img width="538" height="324" alt="image" src="https://github.com/user-attachments/assets/052f70b4-b250-4454-9e93-fb2fa177f50d" />

https://buildkite.com/automattic/day-one-apple/builds/7132/list?tab=output&jid=019f6a2e-b2cf-44b0-845c-662f779d7436#L411


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.