### PR TITLE
Release 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on the macOS fleet, avoiding billed S3 egress, and annotates the job whenever a restore falls back to S3. [#216]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,12 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 6.1.1
+
+### Internal Changes
+
+- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on the macOS fleet, avoiding billed S3 egress, and annotates the job whenever a restore falls back to S3. [#216]
 
 ## 6.1.0
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#6.1.0:
+      - automattic/a8c-ci-toolkit#6.1.1:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.1.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.1.1`.
 
 ## Configuration
 


### PR DESCRIPTION
## 6.1.1

### Internal Changes

- `restore_cache` now fetches from the on-premises Synology NAS before falling back to S3 on the macOS fleet, avoiding billed S3 egress, and annotates the job whenever a restore falls back to S3. [#216]