### PR TITLE
Adopt `#!/usr/bin/env bash` shebang across scripts

### DIFF
--- a/.cursor/rules/bash_scripts.mdc
+++ b/.cursor/rules/bash_scripts.mdc
@@ -15,11 +15,11 @@ For all bash shell scripts:
 ## Best Practices
 
 For all bash shell scripts:
-- Use `#!/bin/bash` as the first line of the script (a.k.a. shebang)
+- Use `#!/usr/bin/env bash` as the first line of the script (a.k.a. shebang), with a single parameter and no flags after `bash` (the kernel passes `env` everything after the interpreter as one argument, so `#!/usr/bin/env bash -eu` is not portable)
 - Use `set -e` to exit on error
 - Use `set -u` to error on undefined variables
 - Use `set -o pipefail` for proper error handling
-- Combine those options in a single `set -euo pipefail` command, or as part of the shebang line, as appropriate
+- Combine those options in a single `set -euo pipefail` command near the top of the script body
 - Always use `$()` instead of backticks to execute commands
 - Quote all variable expansions
 - Use `[[ ]]` for conditional expressions
@@ -52,7 +52,7 @@ When editing or creating files:
 ## Documentation Template
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script: {filename}
 # 

--- a/.cursor/rules/bash_scripts.mdc
+++ b/.cursor/rules/bash_scripts.mdc
@@ -19,7 +19,7 @@ For all bash shell scripts:
 - Use `set -e` to exit on error
 - Use `set -u` to error on undefined variables
 - Use `set -o pipefail` for proper error handling
-- Combine those options in a single `set -euo pipefail` command near the top of the script body
+- Combine those options in a single `set -euo pipefail` command immediately after the shebang, separated with one empty line
 - Always use `$()` instead of backticks to execute commands
 - Quote all variable expansions
 - Use `[[ ]]` for conditional expressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Switch all `bin/` and `hooks/` bash scripts from `#!/bin/bash` to `#!/usr/bin/env bash`, and update the `.cursor` bash guidance to match. Scripts that carried flags in the shebang (`#!/bin/bash -eu`) now set them in the body (`set -eu`), since flags after `bash` are not portable with `env`. [#PR]
 
 ## 6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Switch all `bin/` and `hooks/` bash scripts from `#!/bin/bash` to `#!/usr/bin/env bash`, and update the `.cursor` bash guidance to match. Scripts that carried flags in the shebang (`#!/bin/bash -eu`) now set them in the body (`set -eu`), since flags after `bash` are not portable with `env`. [#219]
+- Switch all `bin/` and `hooks/` bash scripts from `#!/bin/bash` to `#!/usr/bin/env bash`. [#219]
 
 ## 6.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Switch all `bin/` and `hooks/` bash scripts from `#!/bin/bash` to `#!/usr/bin/env bash`, and update the `.cursor` bash guidance to match. Scripts that carried flags in the shebang (`#!/bin/bash -eu`) now set them in the body (`set -eu`), since flags after `bash` are not portable with `env`. [#PR]
+- Switch all `bin/` and `hooks/` bash scripts from `#!/bin/bash` to `#!/usr/bin/env bash`, and update the `.cursor` bash guidance to match. Scripts that carried flags in the shebang (`#!/bin/bash -eu`) now set them in the body (`set -eu`), since flags after `bash` are not portable with `env`. [#219]
 
 ## 6.1.1
 

--- a/bin/add_host_to_ssh_known_hosts
+++ b/bin/add_host_to_ssh_known_hosts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Parameter can be just a host name, or a full http, https or git URL.

--- a/bin/add_host_to_ssh_known_hosts
+++ b/bin/add_host_to_ssh_known_hosts
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Parameter can be just a host name, or a full http, https or git URL.
 URL="${1:?You need to provide an URL as first parameter}"

--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 NEW_SSH_KEY=$1
 NEW_SSH_KEY_NAME=$2

--- a/bin/add_ssh_key_to_agent
+++ b/bin/add_ssh_key_to_agent
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 NEW_SSH_KEY=$1

--- a/bin/build_and_test_pod
+++ b/bin/build_and_test_pod
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 #
 # Any arguments passed to this script will be passed through to `fastlane`.
 # If no argument is passed, the `test` lane will be called by default.

--- a/bin/build_and_test_pod
+++ b/bin/build_and_test_pod
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 #
 # Any arguments passed to this script will be passed through to `fastlane`.

--- a/bin/cache_cocoapods
+++ b/bin/cache_cocoapods
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # This file is deprecated, but is being kept around until v2.0
 

--- a/bin/cache_cocoapods
+++ b/bin/cache_cocoapods
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # This file is deprecated, but is being kept around until v2.0

--- a/bin/cache_cocoapods_specs_repos
+++ b/bin/cache_cocoapods_specs_repos
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Update CocoaPods's master specs repo (used when you don't use the CDN)

--- a/bin/cache_cocoapods_specs_repos
+++ b/bin/cache_cocoapods_specs_repos
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Update CocoaPods's master specs repo (used when you don't use the CDN)
 bundle exec pod repo update --verbose

--- a/bin/cache_repo
+++ b/bin/cache_repo
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 AWS_BUCKET=$1

--- a/bin/cache_repo
+++ b/bin/cache_repo
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 AWS_BUCKET=$1
 

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # This script is used to comment on a pull request, and must be run in a buldkite PR step.
 #

--- a/bin/comment_on_pr
+++ b/bin/comment_on_pr
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # This script is used to comment on a pull request, and must be run in a buldkite PR step.

--- a/bin/comment_with_dependency_diff
+++ b/bin/comment_with_dependency_diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used in a Buildkite CI pipeline to analyze and comment on dependency changes in a
 # GitHub pull request (PR). It compares the Gradle project dependencies and build environment between the

--- a/bin/comment_with_manifest_diff
+++ b/bin/comment_with_manifest_diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/bin/craft_comment_with_dependency_diff
+++ b/bin/craft_comment_with_dependency_diff
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to craft a comment with a dependency diff and a build environment diff.
 # It's extracted from comment_with_dependency_diff to be tested in isolation.

--- a/bin/download_artifact
+++ b/bin/download_artifact
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Usage
 # download_artifact $file_name [$destination]

--- a/bin/download_artifact
+++ b/bin/download_artifact
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Usage

--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 echo "--- :ruby: Ruby environment info dump ${1:-}"

--- a/bin/dump_ruby_env_info
+++ b/bin/dump_ruby_env_info
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 echo "--- :ruby: Ruby environment info dump ${1:-}"
 

--- a/bin/get_libc_version
+++ b/bin/get_libc_version
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 #

--- a/bin/get_libc_version
+++ b/bin/get_libc_version
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 #
 # Returns the system's libc version, or a close proxy of it.

--- a/bin/git-conceal-unlock
+++ b/bin/git-conceal-unlock
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Description:
 #   A wrapper script to run `git-conceal unlock` on CI

--- a/bin/github_api
+++ b/bin/github_api
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Similar to `gh api <endpoint>`, this utility makes API calls to GitHub.

--- a/bin/github_api
+++ b/bin/github_api
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Similar to `gh api <endpoint>`, this utility makes API calls to GitHub.
 #

--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 DIRECTORY_PATH=$1
 

--- a/bin/hash_directory
+++ b/bin/hash_directory
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 DIRECTORY_PATH=$1

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 if [ -z "${1:-}" ]; then
 	echo "You must pass a filename to hash"

--- a/bin/hash_file
+++ b/bin/hash_file
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 if [ -z "${1:-}" ]; then

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Start by restoring specs repo and pod cache:
 # - The specs repo cache holds all of the Podspec files. This avoids having download them all from the CDN.

--- a/bin/install_cocoapods
+++ b/bin/install_cocoapods
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Start by restoring specs repo and pod cache:

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 PLATFORM=$(uname -s)

--- a/bin/install_gems
+++ b/bin/install_gems
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 PLATFORM=$(uname -s)
 ARCHITECTURE=$(uname -m)

--- a/bin/install_npm_packages
+++ b/bin/install_npm_packages
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Ensure package.json is present

--- a/bin/install_npm_packages
+++ b/bin/install_npm_packages
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Ensure package.json is present
 if [ ! -f package.json ]; then

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 print_usage() {

--- a/bin/install_swiftpm_dependencies
+++ b/bin/install_swiftpm_dependencies
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 print_usage() {
   echo "Usage:"

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Attempts to generate the frozen `.strings` file to gets sent to GlotPress

--- a/bin/lint_localized_strings_format
+++ b/bin/lint_localized_strings_format
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Attempts to generate the frozen `.strings` file to gets sent to GlotPress
 # after a new release code freeze.

--- a/bin/lint_pod
+++ b/bin/lint_pod
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/bin/lint_pod
+++ b/bin/lint_pod
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 echo "--- :rubygems: Setting up Gems"

--- a/bin/merge_junit_reports
+++ b/bin/merge_junit_reports
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Initialize variables
 reports_dir=""

--- a/bin/nvm_install
+++ b/bin/nvm_install
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo 'The nvm_install utility has been removed and replaced by our nvm Buildkite plugin.'
 echo 'Please see this migration guide for details: https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/blob/trunk/MIGRATION.md#from-200-to-300'

--- a/bin/patch-cocoapods
+++ b/bin/patch-cocoapods
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a hack to workaround https://github.com/CocoaPods/CocoaPods/issues/12033.
 # We can remove this script once the issue is fixed.

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # This script checks if files are changed in a PR.

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # This script checks if files are changed in a PR.
 #

--- a/bin/prepare_to_publish_to_s3_params
+++ b/bin/prepare_to_publish_to_s3_params
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PARAMS=(--sha1="$BUILDKITE_COMMIT")
 [[ -n "$BUILDKITE_TAG" ]] && PARAMS+=(--tag-name="$BUILDKITE_TAG")

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Usage: publish_pod [OPTIONS] PODSPEC_PATH
 #

--- a/bin/publish_pod
+++ b/bin/publish_pod
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Usage: publish_pod [OPTIONS] PODSPEC_PATH

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Usage: publish_private_pod [OPTIONS] PODSPEC_PATH PRIVATE_SPECS_REPO DEPLOY_KEY

--- a/bin/publish_private_pod
+++ b/bin/publish_private_pod
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Usage: publish_private_pod [OPTIONS] PODSPEC_PATH PRIVATE_SPECS_REPO DEPLOY_KEY
 #

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 CACHE_KEY=$1

--- a/bin/restore_cache
+++ b/bin/restore_cache
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 CACHE_KEY=$1
 

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`

--- a/bin/restore_gradle_dependency_cache
+++ b/bin/restore_gradle_dependency_cache
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # The key is shared with `bin/save_gradle_dependency_cache`
 GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 echo "--- :swift: Running SwiftLint"

--- a/bin/run_swiftlint
+++ b/bin/run_swiftlint
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 echo "--- :swift: Running SwiftLint"
 

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 CACHE_FILE=$1
 CACHE_KEY=$2

--- a/bin/save_cache
+++ b/bin/save_cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 CACHE_FILE=$1

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`

--- a/bin/save_gradle_dependency_cache
+++ b/bin/save_gradle_dependency_cache
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # The key is shared with `bin/restore_gradle_dependency_cache`
 GRADLE_DEPENDENCY_CACHE_KEY="${BUILDKITE_PIPELINE_SLUG}_GRADLE_DEPENDENCY_CACHE_V2"

--- a/bin/slack_notify_pod_published
+++ b/bin/slack_notify_pod_published
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 PODSPEC_PATH=$1
 SLACK_WEBHOOK=$2

--- a/bin/slack_notify_pod_published
+++ b/bin/slack_notify_pod_published
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 PODSPEC_PATH=$1

--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Usage
 # upload_artifact $file_path

--- a/bin/upload_artifact
+++ b/bin/upload_artifact
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Usage

--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 if [ -z "${1: }" ]; then
   echo "You must pass a path to the file you want to upload to Test Analytics"

--- a/bin/upload_buildkite_test_analytics_junit
+++ b/bin/upload_buildkite_test_analytics_junit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 if [ -z "${1: }" ]; then

--- a/bin/upload_sarif_to_github
+++ b/bin/upload_sarif_to_github
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/bin/validate_gemfile_lock
+++ b/bin/validate_gemfile_lock
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # We always need to run `bundle install` first, otherwise we can't compare

--- a/bin/validate_gemfile_lock
+++ b/bin/validate_gemfile_lock
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # We always need to run `bundle install` first, otherwise we can't compare
 bundle install

--- a/bin/validate_gradle_wrapper
+++ b/bin/validate_gradle_wrapper
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 CHECKSUM_URLS=$(curl -s https://services.gradle.org/versions/all | jq -r ".[].wrapperChecksumUrl? | select(.)")
 

--- a/bin/validate_gradle_wrapper
+++ b/bin/validate_gradle_wrapper
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 CHECKSUM_URLS=$(curl -s https://services.gradle.org/versions/all | jq -r ".[].wrapperChecksumUrl? | select(.)")

--- a/bin/validate_podfile_lock
+++ b/bin/validate_podfile_lock
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 PODFILE_SHA1=$(ruby -e "require 'yaml';puts YAML.load_file('Podfile.lock')['PODFILE CHECKSUM']")
 RESULT=$(echo "$PODFILE_SHA1 *Podfile" | shasum -c)

--- a/bin/validate_podfile_lock
+++ b/bin/validate_podfile_lock
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 PODFILE_SHA1=$(ruby -e "require 'yaml';puts YAML.load_file('Podfile.lock')['PODFILE CHECKSUM']")

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 
 # Usage: validate_podspec [OPTIONS] [PODSPEC(S)_PATH(S)...] 
 #

--- a/bin/validate_podspec
+++ b/bin/validate_podspec
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 
 # Usage: validate_podspec [OPTIONS] [PODSPEC(S)_PATH(S)...] 

--- a/bin/validate_swift_package
+++ b/bin/validate_swift_package
@@ -1,4 +1,5 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+set -eu
 #
 # Any arguments passed to this script will be passed through to `fastlane`.
 # If no argument is passed, the `test` lane will be called by default.

--- a/bin/validate_swift_package
+++ b/bin/validate_swift_package
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -eu
 #
 # Any arguments passed to this script will be passed through to `fastlane`.

--- a/hooks/environment
+++ b/hooks/environment
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The `pre-command` hook will run just before your build command runs
 


### PR DESCRIPTION
## Why

Resolve `bash` via `PATH` instead of hardcoding `/bin/bash`, so scripts pick up a newer `bash` when one is installed ahead of the system copy (the stock macOS `/bin/bash` is 3.2). Updates the repo's own `.cursor` bash guidance to recommend `#!/usr/bin/env bash` so new scripts follow suit.

Stacked on #218 — review/merge that first.

## Tradeoff worth a look

Scripts that had flags in the shebang (`#!/bin/bash -eu`) can't become `#!/usr/bin/env bash -eu`: the kernel hands `bash -eu` to `env` as one argument, so it wouldn't run. Those (`hash_file`, `get_libc_version`) now set the flags in the body via `set -eu` instead. Behavior is unchanged.

Ruby (`#!/usr/bin/env ruby`) and PowerShell scripts are untouched.

## How to test

`make lint` (shellcheck across all scripts) and `make test`. All 45 migrated scripts are shellcheck-clean.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
