### PR TITLE
Release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,21 @@ _None._
 
 ### New Features
 
-- Add `install_a8c-secrets_binary`, which installs the `a8c-secrets` CLI from a version-pinned release and verifies its SHA-256 against a vendored checksum before installing, so consuming repos stop piping the mutable upstream `install.sh` from `main`. [#218]
+_None._
 
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## 6.2.0
+
+### New Features
+
+- Add `install_a8c-secrets_binary`, which installs the `a8c-secrets` CLI from a version-pinned release and verifies its SHA-256 against a vendored checksum before installing, so consuming repos stop piping the mutable upstream `install.sh` from `main`. [#218]
 
 ### Internal Changes
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#6.1.1:
+      - automattic/a8c-ci-toolkit#6.2.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.1.1`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.2.0`.
 
 ## Configuration
 


### PR DESCRIPTION

Once merged, the GitHub Release named `6.2.0` gets created with this section's content as the description, which creates the tag.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.