### PR TITLE
Update Xcode image to 26.6 via shared-pipeline-vars

### DIFF
--- a/.buildkite/pipeline-bash-tests.yml
+++ b/.buildkite/pipeline-bash-tests.yml
@@ -5,7 +5,7 @@
 agents:
   queue: mac
 env:
-  IMAGE_ID: xcode-15.4
+  IMAGE_ID: $IMAGE_ID
 
 steps:
   - group: ":c: get_libc_version Tests"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@
 agents:
   queue: mac
 env:
-  IMAGE_ID: xcode-15.4
+  IMAGE_ID: $IMAGE_ID
 
 steps:
   - label: ":sleuth_or_spy: Lint"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+# This repo is not an Xcode project, so we hardcode the version here rather than
+# using a `.xcode-version` file like our Apple projects do.
+XCODE_VERSION=26.6
+
+export IMAGE_ID="xcode-$XCODE_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Bump the Xcode image used by this repo's own CI from `xcode-15.4` to `xcode-26.6`, and introduce `.buildkite/shared-pipeline-vars` so that version is now defined in a single place. [#222]
 
 ## 6.2.0
 

--- a/tests/install_swiftpm_dependencies/test_scripts/run_tests_with_xcodebuild.sh
+++ b/tests/install_swiftpm_dependencies/test_scripts/run_tests_with_xcodebuild.sh
@@ -6,5 +6,5 @@ echo "--- :xcode: Run tests to verify packages have been fetched and are availab
 xcodebuild test \
   -scheme Demo \
   -configuration Debug \
-  -destination 'platform=iOS Simulator' \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
   | xcbeautify


### PR DESCRIPTION
## Context

Both macOS pipelines in this repo hardcoded **`IMAGE_ID: xcode-15.4`** — two majors behind what the projects consuming this plugin actually run (most are on `xcode-26.6`), and duplicated across two files so they could drift apart.

This came out of an audit of our infra inventory for repos still pinned below Xcode 26 [^1]. This repo stood out: it's our shared CI plugin, used by most other pipelines, yet testing itself on an image far older than its consumers.

[^1]: I noticed when I SSH'd into one of our macos-hosts that it still had old `/opt/ci/vm-images/xcode-*` VMs for old Xcode taking disk spaces just because some projects were still pinned on those old images. So this led to a hunt (using [`inspect-repos-infra-tools`](https://github.com/Automattic/apps-infra-toolbox/tree/trunk/scripts/inspect-repos-infra-tools) to find out which repos were still using those old Xcodes and thus forcing our macos-hosts to keep their VMs around locally, and our `a8c-ci-toolkit` repo stood out as the one that has the most activity yet still old Xcode (the other ones are repos we rarely update or push new commits to)

## Change

Introduce **`.buildkite/shared-pipeline-vars`** as the single source of truth for the image, and interpolate `$IMAGE_ID` in the pipeline YAMLs instead of repeating a literal:

```sh
XCODE_VERSION=26.6

export IMAGE_ID="xcode-$XCODE_VERSION"
```

Unlike our Apple projects, this repo is **not** an Xcode project, so a `.xcode-version` file would be out of place here — the version is hardcoded in `shared-pipeline-vars` and `IMAGE_ID` derived from it. Bumping Xcode in future is now a one-line change in one file.

| File | Change |
|---|---|
| `.buildkite/shared-pipeline-vars` | **new** — defines `XCODE_VERSION` and exports `IMAGE_ID` |
| `.buildkite/pipeline.yml` | `IMAGE_ID: xcode-15.4` → `IMAGE_ID: $IMAGE_ID` |
| `.buildkite/pipeline-bash-tests.yml` | `IMAGE_ID: xcode-15.4` → `IMAGE_ID: $IMAGE_ID` |

`pipeline-windows-tests.yml` is untouched — it runs on the `windows` queue and never referenced `IMAGE_ID`.

The bash-tests pipeline picks the value up transitively: `pipeline.yml`'s `env:` block is interpolated at upload time, so `IMAGE_ID` is already in the environment of the step that uploads `pipeline-bash-tests.yml`.

## ⚠️ Ready for review, but "do not merge" label — blocked on a companion PR

**Automattic/buildkite-ci#920** must be **deployed first**.

This pipeline's upload step is defined in Terraform and currently uses custom inline steps that never `source` `.buildkite/shared-pipeline-vars`. Until #920 switches it to the shared `pipeline_upload_steps` template, `$IMAGE_ID` would interpolate to an empty string here and the macOS steps would fail.

CI on this PR is therefore expected to be red until #920 is deployed. Once it is, a rebuild here should go green.

## Testing

- `shellcheck` on the new `shared-pipeline-vars` — clean
- No remaining hardcoded Xcode image references anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
