### PR TITLE
Add `checkout_release_branch` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add `checkout_release_branch`, which checks out the `release/*` branch for a given release version and hard-resets it onto `origin`, so the repos that each carried their own copy of `.buildkite/commands/checkout-release-branch.sh` can drop it and call the toolkit command instead. [#223]
+- Add `checkout_release_branch` command [#223]
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `checkout_release_branch`, which checks out the `release/*` branch for a given release version and hard-resets it onto `origin`, so the repos that each carried their own copy of `.buildkite/commands/checkout-release-branch.sh` can drop it and call the toolkit command instead. [#223]
 
 ### Bug Fixes
 

--- a/bin/checkout_release_branch
+++ b/bin/checkout_release_branch
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script: checkout_release_branch
+#
+# Description:
+#   Checks out the `release/*` branch matching a given release version, and hard-resets it
+#   to the commit currently on `origin`.
+#
+#   Buildkite checks out a specific commit by default, leaving the working copy in a detached
+#   HEAD state. Some release steps need to be on the `release/*` branch instead, namely:
+#    - when a `release-pipelines/*.yml` needs to `git push` to the `release/*` branch (for version bumps)
+#    - when a job `pipeline upload`'d by such a pipeline builds from that branch, so that the build
+#      includes the commit that the version bump just added.
+#
+# Usage:
+#   checkout_release_branch [<release-version>]
+#
+# Options:
+#   -h, --help  Print usage and exit.
+#
+# Arguments:
+#   <release-version>  The version whose `release/*` branch to check out, e.g. `25.4`.
+#                      Optional; see the fallbacks described in the notes below.
+#
+# Examples:
+#   # Explicit version, the form to prefer in a pipeline step
+#   checkout_release_branch "$RELEASE_VERSION"
+#
+#   # Version taken from the `RELEASE_VERSION` environment variable
+#   RELEASE_VERSION=25.4 checkout_release_branch
+#
+#   # Version inferred from the `release/25.4` branch the build runs on
+#   checkout_release_branch
+#
+# Notes:
+#   The release version is taken from the first of these that is set and non-empty:
+#    1. the first argument
+#    2. the `RELEASE_VERSION` environment variable
+#    3. the `release/*` branch the build is running on, via `BUILDKITE_BRANCH`
+#
+#   The branch is reset to `FETCH_HEAD` rather than pulled, because Buildkite can reuse a
+#   working copy where a previous job left the local branch at a different commit:
+#    - `reset --hard` rather than `git pull`, to avoid merging if the two have diverged
+#    - `FETCH_HEAD` rather than `origin/<branch>`, which `git fetch <branch>` only updates
+#      opportunistically
+#
+#   Runs on macOS, Linux and Windows agents. On a Windows agent whose step command is not
+#   already running under bash, invoke it as `bash checkout_release_branch <version>`.
+#
+# Returns:
+#   0 on success
+#   1 on a usage error, or when no release version could be determined
+#   The exit code of `git` when the fetch, checkout or reset fails
+#
+# Requirements:
+#   `git`, and a working copy whose `origin` remote holds the release branch.
+
+usage() {
+	echo "usage: checkout_release_branch [<release-version>]"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+	usage
+	exit 0
+fi
+
+if [[ "${1:-}" == -* ]]; then
+	echo "Error: unknown option '$1'." >&2
+	usage >&2
+	exit 1
+fi
+
+if [[ $# -gt 1 ]]; then
+	echo "Error: too many arguments." >&2
+	usage >&2
+	exit 1
+fi
+
+echo "--- :git: Checkout Release Branch"
+
+RELEASE_VERSION="${1:-${RELEASE_VERSION:-}}"
+
+if [[ -z "$RELEASE_VERSION" && "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
+	RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
+fi
+
+if [[ -z "$RELEASE_VERSION" ]]; then
+	echo "Error: no release version. Pass it as \$1, set RELEASE_VERSION, or run on a release/* branch." >&2
+	exit 1
+fi
+
+BRANCH_NAME="release/${RELEASE_VERSION}"
+git fetch origin "$BRANCH_NAME"
+git checkout "$BRANCH_NAME"
+git reset --hard FETCH_HEAD

--- a/bin/checkout_release_branch
+++ b/bin/checkout_release_branch
@@ -38,7 +38,7 @@ set -euo pipefail
 #   The release version is taken from the first of these that is set and non-empty:
 #    1. the first argument
 #    2. the `RELEASE_VERSION` environment variable
-#    3. the `release/*` branch the build is running on, via `BUILDKITE_BRANCH`
+#    3. the branch the build is running on, if it is in the `release/*` form, via `BUILDKITE_BRANCH`
 #
 #   The branch is reset to `FETCH_HEAD` rather than pulled, because Buildkite can reuse a
 #   working copy where a previous job left the local branch at a different commit:

--- a/tests/test_checkout_release_branch.bats
+++ b/tests/test_checkout_release_branch.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+
+# The command's own logic is the version resolution and the exact sequence of git commands
+# it issues, so the tests stub `git` on PATH and assert on the recorded command log. What
+# `reset --hard FETCH_HEAD` then does to a working copy is git's behaviour, not ours — and
+# the plugin-tester image has no `git` to exercise it with anyway. Pinning the sequence is
+# what guards the fix this command was extracted from: a `git pull` here would merge a
+# diverged branch instead of discarding it.
+
+SCRIPT="$BATS_TEST_DIRNAME/../bin/checkout_release_branch"
+
+setup() {
+	# The command reads both of these as fallbacks, so no test may inherit them.
+	unset RELEASE_VERSION BUILDKITE_BRANCH
+
+	TEST_DIR="$(mktemp -d)"
+	GIT_LOG="$TEST_DIR/git-commands.log"
+	export GIT_LOG
+
+	# Record every invocation, one per line. Setting `GIT_FAIL_ON` to the start of a
+	# subcommand makes that one fail, to check the script propagates git's exit code.
+	mkdir -p "$TEST_DIR/bin"
+	cat > "$TEST_DIR/bin/git" <<-'STUB'
+		#!/usr/bin/env bash
+		echo "$*" >> "$GIT_LOG"
+		if [[ -n "${GIT_FAIL_ON:-}" && "$*" == ${GIT_FAIL_ON}* ]]; then
+			echo "fatal: stubbed git failure" >&2
+			exit 128
+		fi
+	STUB
+	chmod +x "$TEST_DIR/bin/git"
+	PATH="$TEST_DIR/bin:$PATH"
+	export PATH
+}
+
+teardown() {
+	rm -rf "$TEST_DIR"
+}
+
+# Assert the command checked out the release branch for `$1` and reset it onto `origin`.
+assert_checked_out() {
+	local version="$1"
+	[ "$(sed -n '1p' "$GIT_LOG")" = "fetch origin release/$version" ]
+	[ "$(sed -n '2p' "$GIT_LOG")" = "checkout release/$version" ]
+	[ "$(sed -n '3p' "$GIT_LOG")" = "reset --hard FETCH_HEAD" ]
+	[ "$(wc -l < "$GIT_LOG" | tr -d '[:space:]')" = "3" ]
+}
+
+assert_working_copy_untouched() {
+	[ ! -s "$GIT_LOG" ]
+}
+
+@test "--help prints usage and exits 0" {
+	run "$SCRIPT" --help
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "usage: checkout_release_branch" ]]
+	assert_working_copy_untouched
+}
+
+@test "-h prints usage and exits 0" {
+	run "$SCRIPT" -h
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "usage: checkout_release_branch" ]]
+}
+
+@test "an unknown option fails" {
+	run "$SCRIPT" --nope
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "unknown option" ]]
+	assert_working_copy_untouched
+}
+
+@test "more than one argument fails" {
+	run "$SCRIPT" 1.2 3.4
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "too many arguments" ]]
+	assert_working_copy_untouched
+}
+
+@test "the release version can come from the first argument" {
+	run "$SCRIPT" 1.2
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "the release version can come from RELEASE_VERSION" {
+	run env RELEASE_VERSION=1.2 "$SCRIPT"
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "the release version can come from a release/* BUILDKITE_BRANCH" {
+	run env BUILDKITE_BRANCH=release/1.2 "$SCRIPT"
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "the argument takes precedence over RELEASE_VERSION" {
+	run env RELEASE_VERSION=9.9 "$SCRIPT" 1.2
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "RELEASE_VERSION takes precedence over BUILDKITE_BRANCH" {
+	run env RELEASE_VERSION=1.2 BUILDKITE_BRANCH=release/9.9 "$SCRIPT"
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "an empty RELEASE_VERSION falls through to BUILDKITE_BRANCH" {
+	run env RELEASE_VERSION= BUILDKITE_BRANCH=release/1.2 "$SCRIPT"
+	[ "$status" -eq 0 ]
+	assert_checked_out 1.2
+}
+
+@test "a version with slashes in it is kept whole" {
+	run env BUILDKITE_BRANCH=release/25.4/hotfix "$SCRIPT"
+	[ "$status" -eq 0 ]
+	assert_checked_out 25.4/hotfix
+}
+
+@test "no version anywhere fails without touching the working copy" {
+	run "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no release version" ]]
+	assert_working_copy_untouched
+}
+
+@test "a BUILDKITE_BRANCH that is not a release branch is not used as a version" {
+	run env BUILDKITE_BRANCH=trunk "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no release version" ]]
+	assert_working_copy_untouched
+}
+
+@test "a branch merely containing release/ is not used as a version" {
+	run env BUILDKITE_BRANCH=feature/release/1.2 "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" =~ "no release version" ]]
+}
+
+@test "a failing fetch stops the command and propagates git's exit code" {
+	run env GIT_FAIL_ON=fetch "$SCRIPT" 1.2
+	[ "$status" -eq 128 ]
+	# Only the fetch ran: no checkout or reset followed it.
+	[ "$(wc -l < "$GIT_LOG" | tr -d '[:space:]')" = "1" ]
+}
+
+@test "a failing checkout stops the command before the reset" {
+	run env GIT_FAIL_ON=checkout "$SCRIPT" 1.2
+	[ "$status" -eq 128 ]
+	[ "$(wc -l < "$GIT_LOG" | tr -d '[:space:]')" = "2" ]
+}


### PR DESCRIPTION
Part of [AINFRA-2828](https://linear.app/a8c/issue/AINFRA-2828/dry-checkout-release-branchsh-scripts-into-a8c-ci-toolkit).

Thirteen app repos each carry a byte-identical copy of `.buildkite/commands/checkout-release-branch.sh`, standardized across them in [AINFRA-2725](https://linear.app/a8c/issue/AINFRA-2725/fix-release-selection-and-checkout-release-branchsh-in-release-tooling). This moves it here as `checkout_release_branch`, so there is one copy to fix the next time it needs fixing. The follow-up PRs in those repos, which delete their copy and call this command instead, are blocked on the next release of this plugin.

### Behaviour

A straight port of the script the repos have today:

- The release version comes from the first argument, else the `RELEASE_VERSION` environment variable, else the `release/*` branch the build is running on.
- The branch is reset to `FETCH_HEAD` rather than pulled, so a working copy that a previous job left at a different commit is corrected rather than merged.

Added on top of the original, to match the conventions of the more recent commands in `bin/`: a `--help` flag, and rejection of unknown options and extra arguments.

### Tests

The tests stub `git` on `PATH` and assert the exact command sequence the script issues. What `reset --hard FETCH_HEAD` then does to a working copy is git's behaviour rather than ours — and the `buildkite/plugin-tester` image ships no `git` to exercise it with. Pinning the sequence is what guards the fix this was extracted from: a `git pull` here would merge a diverged branch instead of discarding it.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.