### PR TITLE
Homogenize option handling across bin/ commands

### DIFF
--- a/bin/checkout_release_branch
+++ b/bin/checkout_release_branch
@@ -61,37 +61,48 @@ usage() {
 	echo "usage: checkout_release_branch [<release-version>]"
 }
 
-if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-	usage
-	exit 0
-fi
+main() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			-h | --help)
+				usage
+				return 0
+				;;
+			-*)
+				echo "Error: unknown option '$1'." >&2
+				usage >&2
+				return 1
+				;;
+			*)
+				break
+				;;
+		esac
+	done
 
-if [[ "${1:-}" == -* ]]; then
-	echo "Error: unknown option '$1'." >&2
-	usage >&2
-	exit 1
-fi
+	if [[ $# -gt 1 ]]; then
+		echo "Error: too many arguments." >&2
+		usage >&2
+		return 1
+	fi
 
-if [[ $# -gt 1 ]]; then
-	echo "Error: too many arguments." >&2
-	usage >&2
-	exit 1
-fi
+	echo "--- :git: Checkout Release Branch"
 
-echo "--- :git: Checkout Release Branch"
+	# Lowercase local so the `RELEASE_VERSION` on the right stays the environment one.
+	local release_version="${1:-${RELEASE_VERSION:-}}"
 
-RELEASE_VERSION="${1:-${RELEASE_VERSION:-}}"
+	if [[ -z "$release_version" && "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
+		release_version="${BUILDKITE_BRANCH#release/}"
+	fi
 
-if [[ -z "$RELEASE_VERSION" && "${BUILDKITE_BRANCH:-}" =~ ^release/ ]]; then
-	RELEASE_VERSION="${BUILDKITE_BRANCH#release/}"
-fi
+	if [[ -z "$release_version" ]]; then
+		echo "Error: no release version. Pass it as \$1, set RELEASE_VERSION, or run on a release/* branch." >&2
+		return 1
+	fi
 
-if [[ -z "$RELEASE_VERSION" ]]; then
-	echo "Error: no release version. Pass it as \$1, set RELEASE_VERSION, or run on a release/* branch." >&2
-	exit 1
-fi
+	local branch_name="release/${release_version}"
+	git fetch origin "$branch_name"
+	git checkout "$branch_name"
+	git reset --hard FETCH_HEAD
+}
 
-BRANCH_NAME="release/${RELEASE_VERSION}"
-git fetch origin "$BRANCH_NAME"
-git checkout "$BRANCH_NAME"
-git reset --hard FETCH_HEAD
+main "$@"

--- a/bin/install_a8c-secrets_binary
+++ b/bin/install_a8c-secrets_binary
@@ -134,7 +134,7 @@ main() {
 				;;
 			--os | --arch | --install-dir)
 				if [[ $# -lt 2 ]]; then
-					echo "missing value for $1" >&2
+					echo "Error: missing value for '$1'." >&2
 					usage >&2
 					return 1
 				fi
@@ -146,7 +146,7 @@ main() {
 				shift 2
 				;;
 			*)
-				echo "unknown option: $1" >&2
+				echo "Error: unknown option '$1'." >&2
 				usage >&2
 				return 1
 				;;

--- a/bin/pr_changed_files
+++ b/bin/pr_changed_files
@@ -112,12 +112,12 @@ while [[ "$#" -gt 0 ]]; do
                 exit 255
             fi
             ;;
-        --*) 
-            echo "Error: unknown option $1" >&2
+        --*)
+            echo "Error: unknown option '$1'." >&2
             exit 255
             ;;
         *)
-            echo "Error: unexpected argument $1" >&2
+            echo "Error: unexpected argument '$1'." >&2
             exit 255
             ;;
     esac

--- a/tests/test_install_a8c-secrets_binary.bats
+++ b/tests/test_install_a8c-secrets_binary.bats
@@ -76,13 +76,13 @@ call() {
 @test "an option missing its value fails" {
 	run "$SCRIPT" --os
 	[ "$status" -eq 1 ]
-	[[ "$output" =~ "missing value for --os" ]]
+	[[ "$output" =~ "missing value for '--os'" ]]
 }
 
 @test "--install-dir missing its value fails" {
 	run "$SCRIPT" --install-dir
 	[ "$status" -eq 1 ]
-	[[ "$output" =~ "missing value for --install-dir" ]]
+	[[ "$output" =~ "missing value for '--install-dir'" ]]
 }
 
 @test "--install-dir appears in the usage string" {


### PR DESCRIPTION
Stacked on #225 (which is stacked on #223) — base is that branch, not `trunk`. No reviewers requested; this is up for discussion on the convention before it's worth anyone's time.

### Why

Three of the 46 commands in `bin/` parse options, and each does it differently:

| | structure | unknown-option message |
|---|---|---|
| `pr_changed_files` | top-level `while`/`case` | `Error: unknown option $1` |
| `install_a8c-secrets_binary` | `main()` + `while`/`case` | `unknown option: $1` |
| `checkout_release_branch` | top-level `if` chain | `Error: unknown option '$1'.` |

The convention picked here takes the **structure** from `install_a8c-secrets_binary` and the **message form** from everywhere else. That split is deliberate: `main()` + `case` is the only shape that extends to an option with a value, but on messages `install_a8c-secrets_binary` is the outlier — its `unknown option: $1` and `missing value for $1` are the only two bare stderr messages in `bin/`, against roughly nine `Error: …` ones elsewhere, including `pr_changed_files`' own.

### Intentional tradeoff

**`pr_changed_files` keeps its top-level parser.** Its parsing is already `while`/`case` — only the `main()` wrapper is missing — and wrapping it means relocating the Buildkite env check and the `git fetch` that run *before* parsing, and converting a set of `exit 255` paths whose codes differ from the other two commands. That is a behaviour-risk refactor for no testability gain, so this PR changes only its two message strings. If the convention lands, that wrapper is a follow-up worth doing on its own.

### Gotcha

`checkout_release_branch`'s version resolution now uses a lowercase local. `local RELEASE_VERSION="${1:-${RELEASE_VERSION:-}}"` would have been reading the variable it was in the middle of declaring, so the local is deliberately named differently from the environment variable it falls back to.

### How to test

`make test` — 39 tests, 0 failures, and `make lint` is clean. The seventeen existing `checkout_release_branch` cases cover every path through the rewritten parser and are unchanged by it; the two `install_a8c-secrets_binary` assertions that quote the message text moved in the same commit as the message.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.

No release notes: no behaviour change beyond the text of three error messages. Also no `CHANGELOG.md` edit on purpose, since #223 and #224 already conflict on that file.
