### PR TITLE
Release 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 6.3.0
+
+### New Features
+
 - Add `checkout_release_branch` command [#223]
 - Export `$A8C_CI_TOOLKIT_PLUGIN_DIR`, so steps running in a container can mount the plugin and use its commands [#224]
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ steps:
       restore_cache $(hash_file package-lock.json)
 
     plugins:
-      - automattic/a8c-ci-toolkit#6.2.0:
+      - automattic/a8c-ci-toolkit#6.3.0:
           bucket: a8c-ci-cache # optional
 ```
 
-Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.2.0`.
+Don't forget to verify what [the latest release](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/releases/latest) is and use that value instead of `6.3.0`.
 
 ## Configuration
 
@@ -51,7 +51,7 @@ steps:
 
       checkout_release_branch "$RELEASE_VERSION"
     plugins:
-      - automattic/a8c-ci-toolkit#6.2.0
+      - automattic/a8c-ci-toolkit#6.3.0
       - docker#v5.13.0:
           image: node:22-bookworm
           expand-volume-vars: true


### PR DESCRIPTION
Prepares the `CHANGELOG.md` and bumps the `README.md` version references for 6.3.0.

Once merged, the GitHub Release named `6.3.0` gets created with this section's content as the description, which creates the tag.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.