### PR TITLE
Correct the AZURE_TIMESTAMP_SERVER scheme in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- `setup_azure_trusted_signing` now documents `AZURE_TIMESTAMP_SERVER` with the `http://` scheme it actually exports. Overriding it with an `https://` URL produces untimestamped signatures, because the Windows signing transport rejects the scheme. [#232]
 
 ## 6.3.0
 

--- a/bin/setup_azure_trusted_signing.ps1
+++ b/bin/setup_azure_trusted_signing.ps1
@@ -16,7 +16,7 @@
     - `SIGNTOOL_PATH`           — path to modern `signtool.exe`
     - `AZURE_FILE_DIGEST`       — `SHA256`
     - `AZURE_TIMESTAMP_DIGEST`  — `SHA256`
-    - `AZURE_TIMESTAMP_SERVER`  — `https://timestamp.acs.microsoft.com`
+    - `AZURE_TIMESTAMP_SERVER`  — `http://timestamp.acs.microsoft.com`
 
 .PARAMETER SkipSmokeTest
     Skip the signing smoke test. Useful when Azure credentials are not
@@ -185,6 +185,9 @@ $env:AZURE_METADATA_JSON = $metadataPath
 $env:SIGNTOOL_PATH = $signtoolPath
 $env:AZURE_FILE_DIGEST = "SHA256"
 $env:AZURE_TIMESTAMP_DIGEST = "SHA256"
+# Keep the `http://` scheme. `mssign32.dll` rejects any timestamp URL that
+# doesn't start with `http`, even though the endpoint itself serves RFC 3161
+# over TLS: https://github.com/PowerShell/PowerShell/issues/25130
 $env:AZURE_TIMESTAMP_SERVER = "http://timestamp.acs.microsoft.com"
 
 # ── Smoke test ───────────────────────────────────────────────────────


### PR DESCRIPTION
See [AINFRA-2847](https://linear.app/a8c/issue/AINFRA-2847).

When we started working on the Artifact Signing, it looked odd to use a timestamp server via HTTP. But when switching to HTTPS, we always run into issues. 

I asked Opus 5 to research deeply the issue and it confirmed that HTTP is the only option, more in https://linear.app/a8c/issue/AINFRA-2847.

This PR adds a bit of documentation for future reference. Given the timestamp server URL is set as a default here, we don't need to worry too much about propagating the gotcha to consumers I don't think. If any will override the value, they shall do it at their own risk and ideally knowing what they're doing. 

<details>
<summary>Details</summary>


`setup_azure_trusted_signing.ps1` documented `AZURE_TIMESTAMP_SERVER` as `https://timestamp.acs.microsoft.com` while exporting `http://`.
That is worse than a stale docstring: the Windows signing transport (`mssign32.dll`, which `signtool` goes through) rejects any timestamp URL not starting with `http`, so anyone trusting the docstring and setting the override to match would end up with untimestamped signatures — which, given Artifact Signing certs are valid for three days, means signatures that stop validating almost immediately.

The endpoint *does* serve RFC 3161 over TLS, so probing it makes HTTPS look viable. That's why the inline comment stays: this gets suggested by review bots periodically, and the next reader needs the reason not to take the suggestion. Background in [AINFRA-2275](https://linear.app/a8c/issue/AINFRA-2275).

### How to test

Docs-only; nothing to run. `make lint` and `make test` are unaffected.

</details>


---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
